### PR TITLE
Changed how floats and ints are compared

### DIFF
--- a/src/interpreter/int.rs
+++ b/src/interpreter/int.rs
@@ -17,12 +17,24 @@ pub enum Int {
 }
 
 impl Int {
-    pub fn from_f64(value: f64) -> Option<Self> {
+    /// Truncates the float and returns Some<Int> if the float was not NaN or Inf
+    #[must_use]
+    pub fn from_f64_trunc(value: f64) -> Option<Self> {
         if value.is_nan() || value.is_infinite() {
             return None;
         }
 
         BigInt::from_f64(value).map(Int::BigInt)
+    }
+
+    /// Converts to float to an int only if it's fractal part is zero, otherwise it returns None
+    #[must_use]
+    pub fn from_f64_if_int(value: f64) -> Option<Self> {
+        if value.fract() == 0.0 {
+            Int::from_f64_trunc(value)
+        } else {
+            None
+        }
     }
 
     #[must_use]

--- a/src/interpreter/value.rs
+++ b/src/interpreter/value.rs
@@ -128,14 +128,22 @@ impl FallibleOrd for Value {
     }
 }
 
+// TODO: is there a way to get rid of this implementation?!??!
 impl FallibleOrd for &Value {
     type Error = anyhow::Error;
 
     fn try_cmp(&self, other: &Self) -> Result<Ordering, Self::Error> {
-        (*self).try_cmp(*other)
+        self.partial_cmp(other).ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} cannot be compared to {}",
+                self.value_type(),
+                other.value_type()
+            )
+        })
     }
 }
 
+// TODO: probably get rid of this and do explicit clones
 impl From<&Value> for Value {
     fn from(value: &Value) -> Self {
         value.clone()

--- a/src/lexer/string.rs
+++ b/src/lexer/string.rs
@@ -34,7 +34,6 @@ impl<'a> StringLexer for Lexer<'a> {
         }
 
         let Some('"') = self.source.peek() else {
-            // dbg!(self.source.create_span(start_offset));
             return Err(Error::help(
                 "Invalid raw string".to_string(),
                 self.source.create_span(start_offset),

--- a/tests/programs/001_math/021_float_int_cmp.ndct
+++ b/tests/programs/001_math/021_float_int_cmp.ndct
@@ -1,0 +1,7 @@
+--PROGRAM--
+assert(1.1 > 1);
+assert_ne(1.1, 1);
+
+print("ok");
+--EXPECT--
+ok

--- a/tests/programs/007_map_and_set/005_every_key_type.ndct
+++ b/tests/programs/007_map_and_set/005_every_key_type.ndct
@@ -3,9 +3,9 @@ fn foo() { 123 }
 let hashmap = %{
     "foo": 1,
     123: 2,
-    123.0: 3,
+    123.1: 3,
     123/23: 4,
-    123 + 0j: 5,
+    123 + 0.5j: 5,
     foo: 6,
     true: 7,
     false: 8,
@@ -24,9 +24,9 @@ fn expect(key, value) {
 
 expect("foo", 1);
 expect(123, 2);
-expect(123.0, 3);
+expect(123.1, 3);
 expect(123/23, 4);
-expect(123 + 0j, 5);
+expect(123 + 0.5j, 5);
 expect(foo, 6);
 expect(true, 7);
 expect(false, 8);

--- a/tests/programs/007_map_and_set/006_float_map.ndct
+++ b/tests/programs/007_map_and_set/006_float_map.ndct
@@ -1,5 +1,10 @@
 --PROGRAM--
 let m = %{0.0, 0.0/0.0, 1.0/0.0};
-print(m.len());
+assert_eq(3, m.len());
+
+let s = %{1, 1.0};
+assert_eq(1, s.len());
+
+print("ok");
 --EXPECT--
-3
+ok

--- a/tests/programs/603_stdlib_seq/003_sorted.ndct
+++ b/tests/programs/603_stdlib_seq/003_sorted.ndct
@@ -1,0 +1,5 @@
+--PROGRAM--
+assert_eq([1.1, 0.9, 1, 1.0].sorted(), [0.9, 1, 1.0, 1.1]);
+print("ok");
+--EXPECT--
+ok


### PR DESCRIPTION
Fixes #35 

* 1.0 is now equal to 1
* 1.0 and 1 have the same hash value and occupy the same dict key