### PR TITLE
🌀 implementation of expanded macro definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
+checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
 
 [[package]]
 name = "autocfg"
@@ -154,9 +154,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
 dependencies = [
  "anstream",
  "anstyle",
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "clipboard-win"
@@ -287,11 +287,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -326,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "linux-raw-sys"
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
 dependencies = [
  "adler2",
 ]
@@ -408,7 +408,7 @@ dependencies = [
  "rustyline",
  "ryu",
  "self_cell",
- "thiserror 2.0.3",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -522,9 +522,9 @@ checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "ordered-float"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65ee1f9701bf938026630b455d5315f490640234259037edb259798b3bcf85e"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
 ]
@@ -626,15 +626,15 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -679,9 +679,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "self_cell"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d369a96f978623eb3dc28807c4852d6cc617fed53da5d3c400feff1ef34a714a"
+checksum = "c2fdfc24bc566f839a2da4c4295b82db7d25a24253867d5c64355abb5799bdbe"
 
 [[package]]
 name = "smallvec"
@@ -758,11 +758,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+checksum = "08f5383f3e0071702bf93ab5ee99b52d26936be9dedd9413067cbdcddcb6141a"
 dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl 2.0.8",
 ]
 
 [[package]]
@@ -778,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.3"
+version = "2.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "f2f357fcec90b3caef6623a099691be676d033b40a058ac95d2a6ade6fa0c943"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
 name = "andy-cpp-macros"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
 name = "andy-cpp-macros"
 version = "0.1.0"
 dependencies = [
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -308,6 +308,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -389,7 +398,7 @@ dependencies = [
  "clap",
  "either",
  "factorial",
- "itertools",
+ "itertools 0.13.0",
  "miette",
  "num",
  "once_cell",

--- a/andy-cpp-macros/Cargo.toml
+++ b/andy-cpp-macros/Cargo.toml
@@ -12,3 +12,4 @@ proc-macro = true
 proc-macro2 = "1.0.79"
 quote = "1.0.35"
 syn = { version = "2.0.55", features = ["full", "extra-traits"] }
+itertools = "0.12.1"

--- a/andy-cpp-macros/src/function.rs
+++ b/andy-cpp-macros/src/function.rs
@@ -1,7 +1,10 @@
+use std::hash::DefaultHasher;
+
 use crate::r#match::{
     is_ref, is_ref_mut, is_ref_of_bigint, is_ref_of_slice_of_value, is_str_ref, is_string,
     path_ends_with,
 };
+use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
@@ -10,10 +13,11 @@ pub struct WrappedFunction {
     pub function_registration: TokenStream,
 }
 
-pub fn wrap_function(function: syn::ItemFn) -> WrappedFunction {
-    let identifier = function.sig.ident.clone();
+pub fn wrap_function(function: syn::ItemFn) -> Vec<WrappedFunction> {
+    let original_identifier = function.sig.ident.clone();
 
-    let mut register_as_function_name = proc_macro2::Literal::string(&identifier.to_string());
+    let mut register_as_function_name =
+        proc_macro2::Literal::string(&original_identifier.to_string());
 
     for attr in &function.attrs {
         if attr.path().is_ident("function") {
@@ -36,6 +40,38 @@ pub fn wrap_function(function: syn::ItemFn) -> WrappedFunction {
         syn::Visibility::Inherited => panic!("only public functions can be wrapped for now"),
     }
 
+    // When we call create_temp_variable we can get multiple definitions for a variable
+    // For instance when a rust function is `fn foo(list: &[Value])` we can define two internal functions for both Tuple and List
+    let functions = function
+        .sig
+        .inputs
+        .iter()
+        .enumerate()
+        .map(|(position, fn_arg)| create_temp_variable(position, fn_arg, &original_identifier))
+        .multi_cartesian_product()
+        .enumerate()
+        .map(|(variation_id, args)| {
+            wrap_single(
+                function.clone(),
+                format_ident!("{}_{}", original_identifier, variation_id),
+                &register_as_function_name,
+                args,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    functions
+}
+
+/// Wraps an original rust function `function` in an outer function with the identifier `identifier`
+/// It's registered with the environment as `register_as_function_name`
+/// The argument translations mapping is defined by `input_arguments`
+fn wrap_single(
+    function: syn::ItemFn,
+    identifier: syn::Ident,
+    register_as_function_name: &proc_macro2::Literal,
+    input_arguments: Vec<Argument>,
+) -> WrappedFunction {
     let inner_ident = format_ident!("{}_inner", identifier);
     let inner = {
         let mut inner = function.clone();
@@ -51,12 +87,15 @@ pub fn wrap_function(function: syn::ItemFn) -> WrappedFunction {
     let mut arguments = Vec::new();
     let mut param_types: Vec<TokenStream> = Vec::new();
 
-    for (position, fn_arg) in function.sig.inputs.iter().enumerate() {
-        if let Some(x) = create_temp_variable(position, fn_arg, &identifier) {
-            argument_init_code_blocks.push(x.initialize_code);
-            arguments.push(x.argument);
-            param_types.push(x.param_type);
-        }
+    for Argument {
+        argument,
+        initialize_code,
+        param_type,
+    } in input_arguments.into_iter()
+    {
+        arguments.push(argument);
+        argument_init_code_blocks.push(initialize_code);
+        param_types.push(param_type);
     }
 
     let return_expr = match function.sig.output {
@@ -124,6 +163,7 @@ pub fn wrap_function(function: syn::ItemFn) -> WrappedFunction {
     }
 }
 
+#[derive(Debug, Clone)]
 struct Argument {
     param_type: TokenStream,
     argument: TokenStream,
@@ -177,7 +217,7 @@ fn create_temp_variable(
     position: usize,
     input: &syn::FnArg,
     identifier: &syn::Ident,
-) -> Option<Argument> {
+) -> Vec<Argument> {
     let argument_var_name = syn::Ident::new(&format!("arg{position}"), identifier.span());
     if let syn::FnArg::Typed(pat_type) = input {
         let ty = &*pat_type.ty;
@@ -186,7 +226,7 @@ fn create_temp_variable(
         if is_ref_mut(ty) && is_string(ty) {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::String },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -195,12 +235,12 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
+            }];
         }
         // The pattern is Callable
         else if path_ends_with(ty, "Callable") {
             let temp_var = syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Function },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -212,13 +252,13 @@ fn create_temp_variable(
                         environment: environment
                     };
                 },
-            });
+            }];
         }
         // The pattern is &HashMap<Value, Value>
         else if is_ref(ty) && path_ends_with(ty, "HashMap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Map },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -227,13 +267,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &*#rc_temp_var.borrow();
                 },
-            });
+            }];
         }
         // The pattern is &mut HashMap<Value, Value>
         else if is_ref_mut(ty) && path_ends_with(ty, "HashMap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Map },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -242,11 +282,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
-        } else if path_ends_with(ty, "DefaultMap") {
+            }];
+        }
+        // The pattern is DefaultMap
+        else if path_ends_with(ty, "DefaultMap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Map },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -255,13 +297,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = (&*#rc_temp_var.borrow(), default.to_owned());
                 },
-            });
+            }];
         }
-        // The pattern is &mut HashMap<Value, Value>
+        // The pattern is DefaultMapMut
         else if path_ends_with(ty, "DefaultMapMut") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Map },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -270,13 +312,14 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = (&mut *#rc_temp_var.try_borrow_mut()?, default.to_owned());
                 },
-            });
+            }];
         }
         // The pattern is exactly &mut Vec
+        // TODO: support this for tuple
         else if is_ref_mut(ty) && path_ends_with(ty, "Vec") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::List },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -285,7 +328,7 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &mut VecDeque
         else if is_ref_mut(ty) && path_ends_with(ty, "VecDeque") {
@@ -381,7 +424,7 @@ fn create_temp_variable(
         else if is_str_ref(ty) {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::String },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -391,12 +434,12 @@ fn create_temp_variable(
                     let #rc_temp_var = #rc_temp_var.borrow();
                     let #argument_var_name = #rc_temp_var.as_ref();
                 },
-            });
+            }];
         }
         // The pattern is &BigInt
         else if is_ref_of_bigint(ty) {
             let big_int = syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Int },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -412,32 +455,44 @@ fn create_temp_variable(
                         _ => panic!("Value #position need to be an Int but wasn't"),
                     }
                 },
-            });
+            }];
         }
         // If we need an owned Value
         else if path_ends_with(ty, "Value") && !is_ref(ty) {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Any },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
                     let #argument_var_name = #argument_var_name.clone();
                 },
-            });
+            }];
         }
         // The pattern is &[Value]
         else if is_ref_of_slice_of_value(ty) {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
-                param_type: quote! { crate::interpreter::function::ParamType::List },
-                argument: quote! { #argument_var_name },
-                initialize_code: quote! {
-                    let crate::interpreter::value::Value::Sequence(crate::interpreter::sequence::Sequence::List(#rc_temp_var)) = #argument_var_name else {
-                        panic!("Value #position needed to be a Sequence::List but wasn't");
-                    };
-                    let #argument_var_name = &*#rc_temp_var.borrow();
+            return vec![
+                Argument {
+                    param_type: quote! { crate::interpreter::function::ParamType::List },
+                    argument: quote! { #argument_var_name },
+                    initialize_code: quote! {
+                        let crate::interpreter::value::Value::Sequence(crate::interpreter::sequence::Sequence::List(#rc_temp_var)) = #argument_var_name else {
+                            panic!("Value #position needed to be a Sequence::List but wasn't");
+                        };
+                        let #argument_var_name = &*#rc_temp_var.borrow();
+                    },
                 },
-            });
+                Argument {
+                    param_type: quote! { crate::interpreter::function::ParamType::Tuple },
+                    argument: quote! { #argument_var_name },
+                    initialize_code: quote! {
+                        let crate::interpreter::value::Value::Sequence(crate::interpreter::sequence::Sequence::Tuple(#rc_temp_var)) = #argument_var_name else {
+                            panic!("Value #position needed to be a Sequence::List but wasn't");
+                        };
+                        let #argument_var_name = &#rc_temp_var;
+                    },
+                },
+            ];
         }
         // The pattern is &BigRational
         else if path_ends_with(ty, "BigRational") && is_ref(ty) {
@@ -455,7 +510,7 @@ fn create_temp_variable(
         }
         // The pattern is BigRational
         else if path_ends_with(ty, "BigRational") && !is_ref(ty) {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Rational },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -465,11 +520,11 @@ fn create_temp_variable(
 
                     let #argument_var_name = *#argument_var_name.clone();
                 },
-            });
+            }];
         }
         // The pattern is Complex64
         else if path_ends_with(ty, "Complex64") && !is_ref(ty) {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Complex },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -479,27 +534,27 @@ fn create_temp_variable(
 
                     let #argument_var_name = #argument_var_name.clone();
                 },
-            });
+            }];
         }
         // The pattern is something like `i64` (but also matches other concrete types)
         else if let syn::Type::Path(path) = ty {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
                     let #argument_var_name = #path :: try_from(#argument_var_name).map_err(|err| crate::interpreter::function::FunctionCallError::ConvertToNativeTypeError(format!("{err}")))?
                 },
-            });
+            }];
         }
         // The pattern is something like '&Number'
         else if let syn::Type::Reference(type_ref) = &*pat_type.ty {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
                     let #argument_var_name = <#type_ref as TryFrom<&mut crate::interpreter::value::Value>> :: try_from(#argument_var_name).map_err(|err| crate::interpreter::function::FunctionCallError::ConvertToNativeTypeError(format!("{err}")))?
                 },
-            });
+            }];
         }
         // The pattern is a trait implementation TODO: this is not implemented
         else if let syn::Type::ImplTrait(syn::TypeImplTrait { .. }) = &*pat_type.ty {
@@ -507,7 +562,7 @@ fn create_temp_variable(
 
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -517,7 +572,7 @@ fn create_temp_variable(
 
                     let #argument_var_name = crate::interpreter::iterator::RcIter::new(Rc::clone(#rc_temp_var));
                 },
-            });
+            }];
         } else {
             panic!("not sure how to handle this type of thing:\n|---> {:?}", ty);
         }

--- a/andy-cpp-macros/src/function.rs
+++ b/andy-cpp-macros/src/function.rs
@@ -38,6 +38,16 @@ pub fn wrap_function(function: syn::ItemFn) -> Vec<WrappedFunction> {
         syn::Visibility::Inherited => panic!("only public functions can be wrapped for now"),
     }
 
+    // If the function has no argument then the cartesian product stuff below doesn't work
+    if function.sig.inputs.is_empty() {
+        return vec![wrap_single(
+            function.clone(),
+            original_identifier,
+            &register_as_function_name,
+            vec![],
+        )];
+    }
+
     // When we call create_temp_variable we can get multiple definitions for a variable
     // For instance when a rust function is `fn foo(list: &[Value])` we can define two internal functions for both Tuple and List
     let functions = function

--- a/andy-cpp-macros/src/function.rs
+++ b/andy-cpp-macros/src/function.rs
@@ -1,5 +1,3 @@
-use std::hash::DefaultHasher;
-
 use crate::r#match::{
     is_ref, is_ref_mut, is_ref_of_bigint, is_ref_of_slice_of_value, is_str_ref, is_string,
     path_ends_with,
@@ -334,7 +332,7 @@ fn create_temp_variable(
         else if is_ref_mut(ty) && path_ends_with(ty, "VecDeque") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -343,13 +341,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &VecDeque
         else if is_ref(ty) && path_ends_with(ty, "VecDeque") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -358,13 +356,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &*#rc_temp_var.try_borrow()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &mut MaxHeap
         else if is_ref_mut(ty) && path_ends_with(ty, "MaxHeap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -373,13 +371,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &MaxHeap
         else if is_ref(ty) && path_ends_with(ty, "MaxHeap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -388,13 +386,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &*#rc_temp_var.try_borrow()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &mut MinHeap
         else if is_ref_mut(ty) && path_ends_with(ty, "MinHeap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -403,13 +401,13 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &mut *#rc_temp_var.try_borrow_mut()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &MinHeap
         else if is_ref(ty) && path_ends_with(ty, "MinHeap") {
             let rc_temp_var =
                 syn::Ident::new(&format!("temp_{argument_var_name}"), identifier.span());
-            return Some(Argument {
+            return vec![Argument {
                 param_type: into_param_type(ty),
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -418,7 +416,7 @@ fn create_temp_variable(
                     };
                     let #argument_var_name = &*#rc_temp_var.try_borrow()?;
                 },
-            });
+            }];
         }
         // The pattern is exactly &str
         else if is_str_ref(ty) {
@@ -496,7 +494,7 @@ fn create_temp_variable(
         }
         // The pattern is &BigRational
         else if path_ends_with(ty, "BigRational") && is_ref(ty) {
-            return Some(Argument {
+            return vec![Argument {
                 param_type: quote! { crate::interpreter::function::ParamType::Rational },
                 argument: quote! { #argument_var_name },
                 initialize_code: quote! {
@@ -506,7 +504,7 @@ fn create_temp_variable(
 
                     let #argument_var_name = &#argument_var_name.clone();
                 },
-            });
+            }];
         }
         // The pattern is BigRational
         else if path_ends_with(ty, "BigRational") && !is_ref(ty) {

--- a/andy-cpp-macros/src/lib.rs
+++ b/andy-cpp-macros/src/lib.rs
@@ -32,9 +32,10 @@ pub fn export_module(_attr: TokenStream, item: TokenStream) -> TokenStream {
     for item in items {
         match item {
             Item::Fn(f) => {
-                let w = wrap_function(f);
-                declarations.push(w.function_declaration);
-                registrations.push(w.function_registration);
+                for fun in wrap_function(f) {
+                    declarations.push(fun.function_declaration);
+                    registrations.push(fun.function_registration);
+                }
             }
             Item::Use(u) => {
                 uses.push(u);

--- a/src/stdlib/list.rs
+++ b/src/stdlib/list.rs
@@ -138,7 +138,7 @@ mod inner {
     pub fn first(list: &[Value]) -> anyhow::Result<Value> {
         list.first()
             .cloned()
-            .ok_or_else(|| anyhow!("the list is empty"))
+            .ok_or_else(|| anyhow!("collection is empty"))
     }
 
     /// Returns a copy of the first element or `unit` if the list is empty.

--- a/src/stdlib/sequence.rs
+++ b/src/stdlib/sequence.rs
@@ -417,7 +417,7 @@ mod inner {
         Value::list(
             mut_seq_to_iterator(seq)
                 .combinations(k)
-                .map(Value::list)
+                .map(Value::tuple)
                 .collect::<Vec<Value>>(),
         )
     }
@@ -426,7 +426,7 @@ mod inner {
         Value::list(
             mut_seq_to_iterator(seq)
                 .permutations(k)
-                .map(Value::list)
+                .map(Value::tuple)
                 .collect::<Vec<Value>>(),
         )
     }
@@ -481,6 +481,8 @@ mod inner {
         )
     }
 
+    // TODO: right now transposed always produces a list, it probably should produce whatever the input type was (if possible)
+    // TODO: this might not be the expected result for sets (since iterators over sets yield tuples)
     pub fn transposed(seq: &mut Sequence) -> EvaluationResult {
         let mut main = mut_seq_to_iterator(seq).collect::<Vec<_>>();
         let mut iterators = Vec::new();


### PR DESCRIPTION
Update the macro system to generate separate functions in case the requested argument type is `&[Value]` in this case functions for both tuple and list will be generated.

This means functions like `first`, `first?`, `last` and `last?` are now available for tuples. 