### PR TITLE
📚 Add documentation to function types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "ndc_lib",
  "owo-colors",
  "rustyline",
+ "strsim",
  "tap",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,7 +365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -449,7 +469,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -581,6 +601,7 @@ version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "derive_more",
  "either",
  "factorial",
  "itertools 0.14.0",
@@ -925,7 +946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1290,7 +1311,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "coolor"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "691defa50318376447a73ced869862baecfab35f6aabaa91a4cd726b315bfe1a"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -296,6 +305,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "crokey"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5ff945e42bb93d29b10ba509970066a269903a932f0ea07d99d8621f97e90d7"
+dependencies = [
+ "crokey-proc_macros",
+ "crossterm",
+ "once_cell",
+ "serde",
+ "strict",
+]
+
+[[package]]
+name = "crokey-proc_macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "665f2180fd82d0ba2bf3deb45fafabb18f23451024ff71ee47f6bfdfb4bbe09e"
+dependencies = [
+ "crossterm",
+ "proc-macro2",
+ "quote",
+ "strict",
+ "syn",
+]
+
+[[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,10 +372,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -597,6 +688,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy-regex"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126"
+dependencies = [
+ "lazy-regex-proc_macros",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "lazy-regex-proc_macros"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.170"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,6 +721,16 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -652,12 +776,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimad"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -673,6 +818,7 @@ dependencies = [
  "rustyline",
  "strsim",
  "tap",
+ "termimad",
 ]
 
 [[package]]
@@ -841,6 +987,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "plotters"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -983,6 +1152,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,6 +1264,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "self_cell"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,10 +1308,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+
+[[package]]
+name = "strict"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "strsim"
@@ -1172,6 +1392,22 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "termimad"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8e19c6dbf107bec01d0e216bb8219485795b7d75328e4fa5ef2756c1be4f8dc"
+dependencies = [
+ "coolor",
+ "crokey",
+ "crossbeam",
+ "lazy-regex",
+ "minimad",
+ "serde",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "terminal_size"
@@ -1387,6 +1623,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1394,6 +1646,12 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +462,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -460,6 +532,12 @@ checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "is-terminal"
@@ -601,6 +679,7 @@ version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "derive_builder",
  "derive_more",
  "either",
  "factorial",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -671,6 +671,7 @@ dependencies = [
  "ndc_lib",
  "owo-colors",
  "rustyline",
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from", "constructor"] }
+derive_builder = { version = "0.20.2" }
 either = "1.15.0"
 factorial = "0.4.0"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ criterion = { version = "0.5.1", features = ["html_reports"] }
 derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from", "constructor"] }
 derive_builder = { version = "0.20.2" }
 either = "1.15.0"
+strsim = "0.11.1"
 factorial = "0.4.0"
 itertools = "0.14.0"
 miette = { version = "7.5.0", features = ["fancy"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ ahash = { version = "0.8.11" }
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
-derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from"] }
+derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from", "constructor"] }
 either = "1.15.0"
 factorial = "0.4.0"
 itertools = "0.14.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ ahash = { version = "0.8.11" }
 anyhow = "1.0.97"
 clap = { version = "4.5.32", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
+derive_more = { version = "2.0.1", features = ["deref", "deref_mut", "from"] }
 either = "1.15.0"
 factorial = "0.4.0"
 itertools = "0.14.0"
@@ -30,5 +31,5 @@ rustyline = { version = "15.0.0", features = ["derive"] }
 ryu = "1.0.20"
 self_cell = "1.1.0"
 serde_json = { version = "1.0.140", features = ["arbitrary_precision"] }
-thiserror = "2.0.12"
 tap = "1.0.1"
+thiserror = "2.0.12"

--- a/benches/src/benchmark.rs
+++ b/benches/src/benchmark.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 fn run_string(input: &str) -> Result<String, InterpreterError> {
     let buf: Vec<u8> = vec![];
-    let mut interpreter = Interpreter::new(Box::new(buf));
+    let mut interpreter = Interpreter::new(buf);
     // TODO: Is this black_box needed?
     interpreter.run_str(black_box(input), false)
 }

--- a/ndc_bin/Cargo.toml
+++ b/ndc_bin/Cargo.toml
@@ -17,3 +17,4 @@ anyhow.workspace = true
 miette.workspace = true
 itertools.workspace = true
 
+

--- a/ndc_bin/Cargo.toml
+++ b/ndc_bin/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 itertools.workspace = true
+strsim.workspace = true
 miette.workspace = true
 ndc_lib.workspace = true
 owo-colors.workspace = true

--- a/ndc_bin/Cargo.toml
+++ b/ndc_bin/Cargo.toml
@@ -9,12 +9,13 @@ name = "ndc"
 path = "src/main.rs"
 
 [dependencies]
-ndc_lib.workspace = true
-clap.workspace = true
-rustyline.workspace = true
-owo-colors.workspace = true
 anyhow.workspace = true
-miette.workspace = true
+clap.workspace = true
 itertools.workspace = true
+miette.workspace = true
+ndc_lib.workspace = true
+owo-colors.workspace = true
+rustyline.workspace = true
+tap.workspace = true
 
 

--- a/ndc_bin/Cargo.toml
+++ b/ndc_bin/Cargo.toml
@@ -18,5 +18,6 @@ ndc_lib.workspace = true
 owo-colors.workspace = true
 rustyline.workspace = true
 tap.workspace = true
+termimad = "0.31.2"
 
 

--- a/ndc_bin/src/docs.rs
+++ b/ndc_bin/src/docs.rs
@@ -4,7 +4,6 @@ use std::cmp::Ordering;
 use std::fmt::Write;
 use strsim::normalized_damerau_levenshtein;
 use tap::Tap;
-use termimad::crossterm::style::Color::{Cyan, Green};
 use termimad::crossterm::style::Stylize;
 use termimad::*;
 

--- a/ndc_bin/src/docs.rs
+++ b/ndc_bin/src/docs.rs
@@ -1,0 +1,102 @@
+use ndc_lib::interpreter::Interpreter;
+use ndc_lib::interpreter::function::{Parameter, TypeSignature};
+use owo_colors::OwoColorize;
+use std::fmt::Write;
+use tap::Tap;
+
+fn chunk_text(text: &str) -> Vec<(String, bool)> {
+    let mut chunks = Vec::new();
+    let mut current_chunk = String::new();
+    let mut inside_quotes = false;
+
+    for c in text.chars() {
+        if c == '`' {
+            // Toggle the quote flag when encountering backticks
+            chunks.push((current_chunk.clone(), inside_quotes));
+            inside_quotes = !inside_quotes;
+            current_chunk.clear();
+        } else {
+            current_chunk.push(c)
+        }
+    }
+
+    // Add the last chunk if there's any remaining
+    if !current_chunk.is_empty() {
+        chunks.push((current_chunk, inside_quotes));
+    }
+
+    chunks
+}
+
+pub fn docs(mut stdout: impl std::io::Write) -> anyhow::Result<()> {
+    let interpreter = Interpreter::new(Vec::new()); // Discard the output
+    let functions = interpreter.environment().borrow().get_all_functions();
+
+    // let mut stdout = std::io::stdout();
+    let str = format!(
+        "\n{} Function Reference {}\n",
+        "═".repeat(20),
+        "═".repeat(20),
+    );
+    writeln!(stdout, "{}", str.bold().white())?;
+
+    let mut iter = functions
+        .into_iter()
+        .flat_map(|x| x.implementations().collect::<Vec<_>>())
+        .collect::<Vec<_>>()
+        .tap_mut(|list| list.sort_by(|(_, l), (_, r)| l.name().cmp(r.name())))
+        .into_iter()
+        .peekable();
+
+    while let Some((type_sig, function)) = iter.next() {
+        write!(stdout, "{}", function.name().bold().bright_blue(),)?;
+
+        match type_sig {
+            TypeSignature::Variadic => {
+                writeln!(stdout, "({})", "args*".white())?;
+            }
+            TypeSignature::Exact(params) => {
+                write!(stdout, "{}", "(".bold())?;
+                let mut param_iter = params.iter().peekable();
+                while let Some(Parameter { name, type_name }) = param_iter.next() {
+                    write!(
+                        stdout,
+                        "{}: {}",
+                        name.white(),
+                        type_name.as_str().bright_yellow()
+                    )?;
+
+                    if param_iter.peek().is_some() {
+                        write!(stdout, ", ")?;
+                    }
+                }
+
+                writeln!(stdout, "{}", ")".bold())?;
+            }
+        }
+
+        let mut documentation = String::new();
+        for (chunk, quoted) in chunk_text(function.documentation()) {
+            if quoted {
+                write!(documentation, "{}", chunk.bright_white())?;
+            } else {
+                write!(documentation, "{}", chunk.bright_green())?;
+            }
+        }
+
+        for line in documentation.lines() {
+            writeln!(stdout, "  {}", line.trim())?;
+        }
+
+        if documentation.is_empty() {
+            writeln!(stdout)?;
+        }
+
+        if iter.peek().is_some() {
+            writeln!(stdout, "{}", "─".repeat(50).bright_black())?;
+            writeln!(stdout)?;
+        }
+    }
+
+    Ok(())
+}

--- a/ndc_bin/src/docs.rs
+++ b/ndc_bin/src/docs.rs
@@ -5,6 +5,7 @@ use std::fmt::Write;
 use strsim::normalized_damerau_levenshtein;
 use tap::Tap;
 use termimad::crossterm::style::Color::{Cyan, Green};
+use termimad::crossterm::style::Stylize;
 use termimad::*;
 
 /// Returns `true` if `needle` is a substring of `haystack` or if they are at least 80% similar
@@ -44,7 +45,6 @@ pub fn docs(query: Option<&str>) -> anyhow::Result<()> {
 
     skin.headers[0].align = Alignment::Left;
     skin.headers[1].align = Alignment::Left;
-    skin.headers[1].set_fg(Green);
     skin.headers[2].align = Alignment::Left;
 
     for (type_sig, function) in matched_functions {
@@ -57,7 +57,7 @@ pub fn docs(query: Option<&str>) -> anyhow::Result<()> {
                 write!(signature, "(")?;
                 let mut param_iter = params.iter().peekable();
                 while let Some(Parameter { name, type_name }) = param_iter.next() {
-                    write!(signature, "*{name}*: **{}**", type_name.as_str())?;
+                    write!(signature, "*{name}*: **{}**", type_name.as_str().green())?;
 
                     if param_iter.peek().is_some() {
                         write!(signature, ", ")?;
@@ -70,7 +70,8 @@ pub fn docs(query: Option<&str>) -> anyhow::Result<()> {
         let name = function.name();
         let documentation = function.documentation().trim();
         let markdown = format!(
-            "---\n\n## **{name}**{signature}\n{documentation}{}",
+            "---\n\n## **{}**{signature}\n{documentation}{}",
+            name.green(),
             if documentation.is_empty() { "" } else { "\n\n" }
         );
 

--- a/ndc_bin/src/docs.rs
+++ b/ndc_bin/src/docs.rs
@@ -1,62 +1,22 @@
 use ndc_lib::interpreter::Interpreter;
 use ndc_lib::interpreter::function::{Parameter, TypeSignature};
-use owo_colors::OwoColorize;
 use std::cmp::Ordering;
 use std::fmt::Write;
 use strsim::normalized_damerau_levenshtein;
 use tap::Tap;
-
-fn chunk_text(text: &str) -> Vec<(String, bool)> {
-    let mut chunks = Vec::new();
-    let mut current_chunk = String::new();
-    let mut inside_quotes = false;
-
-    for c in text.chars() {
-        if c == '`' {
-            // Toggle the quote flag when encountering backticks
-            chunks.push((current_chunk.clone(), inside_quotes));
-            inside_quotes = !inside_quotes;
-            current_chunk.clear();
-        } else {
-            current_chunk.push(c)
-        }
-    }
-
-    // Add the last chunk if there's any remaining
-    if !current_chunk.is_empty() {
-        chunks.push((current_chunk, inside_quotes));
-    }
-
-    chunks
-}
+use termimad::crossterm::style::Color::{Cyan, Green};
+use termimad::*;
 
 /// Returns `true` if `needle` is a substring of `haystack` or if they are at least 80% similar
 fn string_match(needle: &str, haystack: &str) -> bool {
     haystack.contains(needle) || normalized_damerau_levenshtein(needle, haystack) > 0.8
 }
 
-pub fn docs(mut stdout: impl std::io::Write, query: Option<&str>) -> anyhow::Result<()> {
+pub fn docs(query: Option<&str>) -> anyhow::Result<()> {
     let interpreter = Interpreter::new(Vec::new()); // Discard the output
     let functions = interpreter.environment().borrow().get_all_functions();
 
-    // let mut stdout = std::io::stdout();
-    let str = if let Some(query) = query {
-        format!(
-            "\n{} Search results for: {} {}\n",
-            "═".repeat(20),
-            format!("\"{}\"", query).bright_green(),
-            "═".repeat(20),
-        )
-    } else {
-        format!(
-            "\n{} Function Reference {}\n",
-            "═".repeat(20),
-            "═".repeat(20),
-        )
-    };
-    writeln!(stdout, "{}", str.bold().white())?;
-
-    let mut iter = functions
+    let matched_functions = functions
         .into_iter()
         .flat_map(|x| x.implementations().collect::<Vec<_>>())
         .filter(|(_, func)| {
@@ -78,58 +38,43 @@ pub fn docs(mut stdout: impl std::io::Write, query: Option<&str>) -> anyhow::Res
                     l.name().cmp(r.name())
                 }
             })
-        })
-        .into_iter()
-        .peekable();
+        });
 
-    while let Some((type_sig, function)) = iter.next() {
-        write!(stdout, "{}", function.name().bold().bright_blue(),)?;
+    let mut skin = MadSkin::default();
 
+    skin.headers[0].align = Alignment::Left;
+    skin.headers[1].align = Alignment::Left;
+    skin.headers[1].set_fg(Green);
+    skin.headers[2].align = Alignment::Left;
+
+    for (type_sig, function) in matched_functions {
+        let mut signature = String::new();
         match type_sig {
             TypeSignature::Variadic => {
-                writeln!(stdout, "({})", "args*".white())?;
+                writeln!(signature, "(*args**)")?;
             }
             TypeSignature::Exact(params) => {
-                write!(stdout, "{}", "(".bold())?;
+                write!(signature, "(")?;
                 let mut param_iter = params.iter().peekable();
                 while let Some(Parameter { name, type_name }) = param_iter.next() {
-                    write!(
-                        stdout,
-                        "{}: {}",
-                        name.white(),
-                        type_name.as_str().bright_yellow()
-                    )?;
+                    write!(signature, "*{name}*: **{}**", type_name.as_str())?;
 
                     if param_iter.peek().is_some() {
-                        write!(stdout, ", ")?;
+                        write!(signature, ", ")?;
                     }
                 }
 
-                writeln!(stdout, "{}", ")".bold())?;
+                writeln!(signature, ")")?;
             }
         }
+        let name = function.name();
+        let documentation = function.documentation().trim();
+        let markdown = format!(
+            "---\n\n## **{name}**{signature}\n{documentation}{}",
+            if documentation.is_empty() { "" } else { "\n\n" }
+        );
 
-        let mut documentation = String::new();
-        for (chunk, quoted) in chunk_text(function.documentation()) {
-            if quoted {
-                write!(documentation, "{}", chunk.bright_cyan())?;
-            } else {
-                write!(documentation, "{}", chunk.bright_green())?;
-            }
-        }
-
-        for line in documentation.lines() {
-            writeln!(stdout, "  {}", line.trim_end_matches('\n'))?;
-        }
-
-        if documentation.is_empty() {
-            writeln!(stdout)?;
-        }
-
-        if iter.peek().is_some() {
-            writeln!(stdout, "{}", "─".repeat(50).bright_black())?;
-            writeln!(stdout)?;
-        }
+        skin.print_text(&markdown);
     }
 
     Ok(())

--- a/ndc_bin/src/docs.rs
+++ b/ndc_bin/src/docs.rs
@@ -40,11 +40,20 @@ pub fn docs(mut stdout: impl std::io::Write, query: Option<&str>) -> anyhow::Res
     let functions = interpreter.environment().borrow().get_all_functions();
 
     // let mut stdout = std::io::stdout();
-    let str = format!(
-        "\n{} Function Reference {}\n",
-        "═".repeat(20),
-        "═".repeat(20),
-    );
+    let str = if let Some(query) = query {
+        format!(
+            "\n{} Search results for: {} {}\n",
+            "═".repeat(20),
+            format!("\"{}\"", query).bright_green(),
+            "═".repeat(20),
+        )
+    } else {
+        format!(
+            "\n{} Function Reference {}\n",
+            "═".repeat(20),
+            "═".repeat(20),
+        )
+    };
     writeln!(stdout, "{}", str.bold().white())?;
 
     let mut iter = functions
@@ -103,14 +112,14 @@ pub fn docs(mut stdout: impl std::io::Write, query: Option<&str>) -> anyhow::Res
         let mut documentation = String::new();
         for (chunk, quoted) in chunk_text(function.documentation()) {
             if quoted {
-                write!(documentation, "{}", chunk.bright_white())?;
+                write!(documentation, "{}", chunk.bright_cyan())?;
             } else {
                 write!(documentation, "{}", chunk.bright_green())?;
             }
         }
 
         for line in documentation.lines() {
-            writeln!(stdout, "  {}", line.trim())?;
+            writeln!(stdout, "  {}", line.trim_end_matches('\n'))?;
         }
 
         if documentation.is_empty() {

--- a/ndc_bin/src/main.rs
+++ b/ndc_bin/src/main.rs
@@ -37,8 +37,9 @@ enum Command {
     Run { file: Option<PathBuf> },
     /// Output an .ndc file using the built-in syntax highlighting engine
     Highlight { file: PathBuf },
-    /// Output the documentation
-    Docs,
+
+    /// Output the documentation optionally searched using a query string
+    Docs { query: Option<String> },
 
     // This is a fallback case
     #[command(external_subcommand)]
@@ -55,7 +56,7 @@ enum Action {
     RunFile(PathBuf),
     HighlightFile(PathBuf),
     StartRepl,
-    Docs,
+    Docs(Option<String>),
 }
 
 impl TryFrom<Command> for Action {
@@ -66,7 +67,7 @@ impl TryFrom<Command> for Action {
             Command::Run { file: Some(file) } => Self::RunFile(file),
             Command::Run { file: None } => Self::StartRepl,
             Command::Highlight { file } => Self::HighlightFile(file),
-            Command::Docs => Self::Docs,
+            Command::Docs { query } => Self::Docs(query),
             Command::Unknown(args) => {
                 match args.len() {
                     0 => {
@@ -135,7 +136,7 @@ fn main() -> anyhow::Result<()> {
             }
             std::io::stdout().flush()?;
         }
-        Action::Docs => return docs(std::io::stdout()),
+        Action::Docs(query) => return docs(std::io::stdout(), query.as_deref()),
         Action::StartRepl => {
             repl::run(cli.debug)?;
         }

--- a/ndc_bin/src/main.rs
+++ b/ndc_bin/src/main.rs
@@ -136,7 +136,7 @@ fn main() -> anyhow::Result<()> {
             }
             std::io::stdout().flush()?;
         }
-        Action::Docs(query) => return docs(std::io::stdout(), query.as_deref()),
+        Action::Docs(query) => return docs(query.as_deref()),
         Action::StartRepl => {
             repl::run(cli.debug)?;
         }

--- a/ndc_bin/src/repl.rs
+++ b/ndc_bin/src/repl.rs
@@ -36,7 +36,7 @@ pub fn run(debug: bool) -> anyhow::Result<()> {
     rl.set_helper(Some(h));
 
     let stdout = std::io::stdout();
-    let mut interpreter = Interpreter::new(Box::new(stdout));
+    let mut interpreter = Interpreter::new(stdout);
     loop {
         match rl.readline("λ ") {
             Ok(line) => {

--- a/ndc_lib/Cargo.toml
+++ b/ndc_lib/Cargo.toml
@@ -7,6 +7,7 @@ version.workspace = true
 [dependencies]
 ahash = { workspace = true, optional = true }
 anyhow.workspace = true
+derive_more.workspace = true
 either.workspace = true
 factorial.workspace = true
 itertools.workspace = true

--- a/ndc_lib/Cargo.toml
+++ b/ndc_lib/Cargo.toml
@@ -8,6 +8,7 @@ version.workspace = true
 ahash = { workspace = true, optional = true }
 anyhow.workspace = true
 derive_more.workspace = true
+derive_builder.workspace = true
 either.workspace = true
 factorial.workspace = true
 itertools.workspace = true

--- a/ndc_lib/src/interpreter.rs
+++ b/ndc_lib/src/interpreter.rs
@@ -27,9 +27,12 @@ pub struct Interpreter {
 #[allow(clippy::dbg_macro, clippy::print_stdout, clippy::print_stderr)]
 impl Interpreter {
     #[must_use]
-    pub fn new(dest: Box<dyn InterpreterOutput>) -> Self {
+    pub fn new<T>(dest: T) -> Self
+    where
+        T: InterpreterOutput + 'static,
+    {
         Self {
-            environment: Rc::new(RefCell::new(Environment::new_with_stdlib(dest))),
+            environment: Rc::new(RefCell::new(Environment::new_with_stdlib(Box::new(dest)))),
         }
     }
 

--- a/ndc_lib/src/interpreter/environment.rs
+++ b/ndc_lib/src/interpreter/environment.rs
@@ -110,7 +110,7 @@ impl Environment {
         }
 
         // Fallback
-        self.declare(name, Value::from(function));
+        self.declare(name, Value::function(function));
     }
     pub fn declare(&mut self, name: &str, value: Value) {
         self.values.insert(name.into(), RefCell::new(value));

--- a/ndc_lib/src/interpreter/environment.rs
+++ b/ndc_lib/src/interpreter/environment.rs
@@ -1,4 +1,4 @@
-use crate::interpreter::function::Function;
+use crate::interpreter::function::{Function, OverloadedFunction};
 
 use crate::hash_map::HashMap;
 
@@ -61,23 +61,7 @@ impl Environment {
             values: HashMap::default(),
         };
 
-        // TODO: move this out of this module to a more general location
-        crate::stdlib::aoc::register(&mut env);
-        crate::stdlib::cmp::register(&mut env);
-        crate::stdlib::deque::register(&mut env);
-        crate::stdlib::file::register(&mut env);
-        crate::stdlib::hash_map::register(&mut env);
-        crate::stdlib::heap::register(&mut env);
-        crate::stdlib::list::register(&mut env);
-        crate::stdlib::math::f64::register(&mut env);
-        crate::stdlib::math::register(&mut env);
-        crate::stdlib::rand::register(&mut env);
-        crate::stdlib::regex::register(&mut env);
-        crate::stdlib::sequence::extra::register(&mut env);
-        crate::stdlib::sequence::register(&mut env);
-        crate::stdlib::serde::register(&mut env);
-        crate::stdlib::string::register(&mut env);
-        crate::stdlib::value::register(&mut env);
+        crate::stdlib::register(&mut env);
 
         env
     }
@@ -93,6 +77,23 @@ impl Environment {
         // TODO: there is probably a much faster implementation possible
         if let Some(parent) = &self.parent {
             values.extend(parent.borrow().get_all_by_name(name));
+        }
+
+        values
+    }
+
+    #[must_use]
+    pub fn get_all_functions(&self) -> Vec<OverloadedFunction> {
+        let mut values = Vec::new();
+
+        for (_name, value) in &self.values {
+            if let Value::Function(func) = &*value.borrow() {
+                values.push(func.borrow().clone())
+            }
+        }
+
+        if let Some(parent) = &self.parent {
+            values.extend(parent.borrow().get_all_functions());
         }
 
         values

--- a/ndc_lib/src/interpreter/evaluate.rs
+++ b/ndc_lib/src/interpreter/evaluate.rs
@@ -15,7 +15,7 @@ use crate::ast::{
 use crate::hash_map;
 use crate::hash_map::HashMap;
 use crate::interpreter::environment::{Environment, EnvironmentRef};
-use crate::interpreter::function::{Function, FunctionCarrier, OverloadedFunction};
+use crate::interpreter::function::{Function, FunctionBody, FunctionCarrier, OverloadedFunction};
 use crate::interpreter::int::Int;
 use crate::interpreter::iterator::mut_value_to_iterator;
 use crate::interpreter::num::{EuclideanDivisionError, Number};
@@ -363,14 +363,14 @@ pub(crate) fn evaluate_expression(
                 .map(|it| it.try_into_identifier())
                 .transpose()?;
 
-            let mut user_function = Function::Closure {
+            let mut user_function = FunctionBody::Closure {
                 parameter_names: arguments.try_into_parameters()?,
                 body: body.clone(),
                 environment: environment.clone(),
             };
 
             if *pure {
-                user_function = Function::Memoized {
+                user_function = FunctionBody::Memoized {
                     cache: RefCell::default(),
                     function: Box::new(user_function),
                 }
@@ -379,11 +379,11 @@ pub(crate) fn evaluate_expression(
             if let Some(name) = name {
                 environment
                     .borrow_mut()
-                    .declare_function(name, user_function);
+                    .declare_function(name, Function::new(user_function));
 
                 Value::unit()
             } else {
-                user_function.into()
+                Value::function(user_function)
             }
         }
 

--- a/ndc_lib/src/interpreter/evaluate.rs
+++ b/ndc_lib/src/interpreter/evaluate.rs
@@ -1355,7 +1355,7 @@ fn call_function(
             // TODO: for now we just pass the break from inside the function to outside the function. This would allow some pretty funky code and might introduce weird bugs?
             | FunctionCarrier::Break(_),
         ) => e,
-        Err(carrier @ FunctionCarrier::IntoEvaluationError(_)) => Err(carrier.lift(span)),
+        Err(carrier @ FunctionCarrier::IntoEvaluationError(_)) => Err(carrier.lift_if(span)),
     }
 }
 

--- a/ndc_lib/src/interpreter/evaluate.rs
+++ b/ndc_lib/src/interpreter/evaluate.rs
@@ -379,7 +379,7 @@ pub(crate) fn evaluate_expression(
             if let Some(name) = name {
                 environment
                     .borrow_mut()
-                    .declare_function(name, Function::new(user_function));
+                    .declare_function(name, Function::from_body(user_function));
 
                 Value::unit()
             } else {

--- a/ndc_lib/src/interpreter/function.rs
+++ b/ndc_lib/src/interpreter/function.rs
@@ -195,7 +195,7 @@ impl OverloadedFunction {
             .insert(function.type_signature(), function);
     }
 
-    pub fn iter_implementations(&self) -> impl Iterator<Item = (TypeSignature, Function)> {
+    pub fn implementations(&self) -> impl Iterator<Item = (TypeSignature, Function)> {
         self.implementations.clone().into_iter()
     }
 
@@ -247,7 +247,7 @@ fn match_types_to_signature(types: &[ValueType], signature: &TypeSignature) -> O
             if types.len() == signature.len() {
                 let mut acc = 0;
                 for (a, b) in types.iter().zip(signature.iter()) {
-                    let dist = b.param_type.distance(a)?;
+                    let dist = b.type_name.distance(a)?;
                     acc += dist;
                 }
 
@@ -261,15 +261,15 @@ fn match_types_to_signature(types: &[ValueType], signature: &TypeSignature) -> O
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Parameter {
-    name: String,
-    param_type: ParamType,
+    pub name: String,
+    pub type_name: ParamType,
 }
 
 impl Parameter {
     pub fn new<N: Into<String>>(name: N, param_type: ParamType) -> Self {
         Self {
             name: name.into(),
-            param_type,
+            type_name: param_type,
         }
     }
 }
@@ -338,7 +338,7 @@ impl ParamType {
         }
     }
 
-    fn as_str(&self) -> &'static str {
+    pub fn as_str(&self) -> &'static str {
         match self {
             Self::Any => "Any",
             Self::Bool => "Bool",
@@ -462,7 +462,7 @@ impl fmt::Display for TypeSignature {
                 "{}",
                 params
                     .iter()
-                    .map(|p| format!("{}: {}", p.name, p.param_type.as_str()))
+                    .map(|p| format!("{}: {}", p.name, p.type_name.as_str()))
                     .join(", ")
             ),
         }

--- a/ndc_lib/src/interpreter/function.rs
+++ b/ndc_lib/src/interpreter/function.rs
@@ -8,13 +8,11 @@ use crate::interpreter::num::{Number, NumberType};
 use crate::interpreter::sequence::Sequence;
 use crate::interpreter::value::{Value, ValueType};
 use crate::lexer::Span;
-use derive_more::with_trait::{Constructor, Deref, DerefMut};
 use itertools::Itertools;
 use std::cell::{BorrowError, BorrowMutError, RefCell};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
-use tap::Pipe;
 
 /// Callable is a wrapper around a `OverloadedFunction` pointer and the environment to make it
 /// easy to have an executable function as a method signature in the standard library
@@ -28,11 +26,9 @@ impl Callable<'_> {
         self.function.borrow().call(args, self.environment)
     }
 }
-#[derive(Clone, Deref, DerefMut)]
+#[derive(Clone)]
 pub struct Function {
     documentation: Option<String>,
-    #[deref]
-    #[deref_mut]
     body: FunctionBody,
 }
 
@@ -52,6 +48,14 @@ impl Function {
     }
     pub fn documentation(&self) -> &str {
         self.documentation.as_deref().unwrap_or_default()
+    }
+
+    pub fn body(&self) -> &FunctionBody {
+        &self.body
+    }
+
+    pub fn type_signature(&self) -> TypeSignature {
+        self.body.type_signature()
     }
 }
 
@@ -201,7 +205,7 @@ impl OverloadedFunction {
         }
 
         if let Some(function) = best {
-            function.call(args, env)
+            function.body().call(args, env)
         } else {
             Err(FunctionCarrier::FunctionNotFound)
         }

--- a/ndc_lib/src/interpreter/heap.rs
+++ b/ndc_lib/src/interpreter/heap.rs
@@ -1,26 +1,16 @@
 use crate::interpreter::value::Value;
+use derive_more::{Deref, DerefMut};
 use std::cmp::{Ordering, Reverse};
 use std::collections::BinaryHeap;
-use std::ops::{Deref, DerefMut};
 
 pub type MinHeap = ManagedHeap<Reverse<HeapValue>>;
 pub type MaxHeap = ManagedHeap<HeapValue>;
 
+#[derive(Deref, DerefMut)]
 pub struct ManagedHeap<T> {
+    #[deref]
+    #[deref_mut]
     heap: BinaryHeap<T>,
-}
-
-impl<T> Deref for ManagedHeap<T> {
-    type Target = BinaryHeap<T>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.heap
-    }
-}
-impl<T> DerefMut for ManagedHeap<T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.heap
-    }
 }
 
 impl<T> Default for ManagedHeap<T>
@@ -87,26 +77,12 @@ impl FromIterator<Value> for MaxHeap {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Deref, DerefMut)]
 pub struct HeapValue(pub Value);
 
 impl From<HeapValue> for Value {
     fn from(value: HeapValue) -> Self {
         value.0
-    }
-}
-
-impl Deref for HeapValue {
-    type Target = Value;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for HeapValue {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 
@@ -126,6 +102,5 @@ impl PartialOrd for HeapValue {
 impl Ord for HeapValue {
     fn cmp(&self, other: &Self) -> Ordering {
         self.0.partial_cmp(&other.0).unwrap_or(Ordering::Equal)
-        // .expect("checked heap must guarantee this never happens")
     }
 }

--- a/ndc_lib/src/interpreter/value.rs
+++ b/ndc_lib/src/interpreter/value.rs
@@ -10,7 +10,7 @@ use num::BigInt;
 
 use crate::compare::FallibleOrd;
 use crate::hash_map::DefaultHasher;
-use crate::interpreter::function::{Function, OverloadedFunction};
+use crate::interpreter::function::OverloadedFunction;
 use crate::interpreter::int::Int;
 use crate::interpreter::num::{Number, NumberToFloatError, NumberToUsizeError, NumberType};
 use crate::interpreter::sequence::Sequence;
@@ -51,6 +51,10 @@ impl Value {
 
     pub(crate) fn some(value: Self) -> Self {
         Self::Option(Some(Box::new(value)))
+    }
+
+    pub(crate) fn function<T: Into<OverloadedFunction>>(source: T) -> Self {
+        Self::Function(Rc::new(RefCell::new(source.into())))
     }
 
     /// If this value is a type of `Sequence` it returns the length of the sequence, otherwise it returns `None`
@@ -346,12 +350,6 @@ impl From<String> for Value {
 impl From<&str> for Value {
     fn from(value: &str) -> Self {
         Self::Sequence(Sequence::String(Rc::new(RefCell::new(value.to_string()))))
-    }
-}
-
-impl From<Function> for Value {
-    fn from(value: Function) -> Self {
-        Self::Function(Rc::new(RefCell::new(OverloadedFunction::from(value))))
     }
 }
 

--- a/ndc_lib/src/stdlib.rs
+++ b/ndc_lib/src/stdlib.rs
@@ -1,3 +1,5 @@
+use crate::interpreter::environment::Environment;
+
 pub mod aoc;
 pub mod cmp;
 pub mod deque;
@@ -12,3 +14,23 @@ pub mod sequence;
 pub mod serde;
 pub mod string;
 pub mod value;
+
+pub fn register(env: &mut Environment) {
+    aoc::register(env);
+    cmp::register(env);
+    deque::register(env);
+    file::register(env);
+    file::register_variadic(env);
+    hash_map::register(env);
+    heap::register(env);
+    list::register(env);
+    math::f64::register(env);
+    math::register(env);
+    rand::register(env);
+    regex::register(env);
+    sequence::extra::register(env);
+    sequence::register(env);
+    serde::register(env);
+    string::register(env);
+    value::register(env);
+}

--- a/ndc_lib/src/stdlib/aoc.rs
+++ b/ndc_lib/src/stdlib/aoc.rs
@@ -9,6 +9,7 @@ mod inner {
     use crate::interpreter::sequence::Sequence;
     use crate::interpreter::value::Value;
 
+    /// Counts the occurrences of each item in a sequence and returns a map with the frequencies.
     pub fn frequencies(seq: &mut Sequence) -> Value {
         let mut out_map = HashMap::new();
 

--- a/ndc_lib/src/stdlib/cmp.rs
+++ b/ndc_lib/src/stdlib/cmp.rs
@@ -6,6 +6,7 @@ mod inner {
     use crate::interpreter::value::Value;
     use std::cmp::Ordering;
 
+    /// Produces an error if the argument is not true.
     pub fn assert(value: bool) -> anyhow::Result<Value> {
         if value {
             Ok(Value::unit())
@@ -14,6 +15,7 @@ mod inner {
         }
     }
 
+    /// Produces an error if the arguments aren't equal to each other.
     pub fn assert_eq(left: &Value, right: &Value) -> anyhow::Result<Value> {
         if left == right {
             Ok(Value::unit())
@@ -24,6 +26,7 @@ mod inner {
         }
     }
 
+    /// Produces an error if the arguments are equal to each other.
     pub fn assert_ne(left: &Value, right: &Value) -> anyhow::Result<Value> {
         if left == right {
             Err(anyhow!(format!(
@@ -34,6 +37,7 @@ mod inner {
         }
     }
 
+    /// Produces the error specified by the `message` parameter if the `value` argument is not true.
     #[function(name = "assert")]
     pub fn assert_with_message(value: bool, message: &str) -> anyhow::Result<Value> {
         if value {
@@ -43,6 +47,7 @@ mod inner {
         }
     }
 
+    /// Returns the larger of `left` and `right`, preferring `left` if they are equal.
     pub fn max(left: &Value, right: &Value) -> Result<Value, anyhow::Error> {
         match left.try_cmp(right)? {
             Ordering::Equal | Ordering::Greater => Ok(left.clone()),
@@ -50,6 +55,7 @@ mod inner {
         }
     }
 
+    /// Returns the smaller of `left` and `right`, preferring `left` if they are equal.
     pub fn min(left: &Value, right: &Value) -> Result<Value, anyhow::Error> {
         match left.try_cmp(right)? {
             Ordering::Equal | Ordering::Less => Ok(left.clone()),

--- a/ndc_lib/src/stdlib/deque.rs
+++ b/ndc_lib/src/stdlib/deque.rs
@@ -8,41 +8,51 @@ mod inner {
     use std::collections::VecDeque;
     use std::rc::Rc;
 
+    /// Creates a new `Deque` type.
+    ///
+    /// The `Deque` type allows the user to quickly append and remove elements from both the start and the end of the list.
     #[function(name = "Deque")]
     pub fn create_deque() -> Value {
         Value::Sequence(Sequence::Deque(Rc::new(RefCell::new(VecDeque::new()))))
     }
 
+    /// Pushes the `value` to the front of the `deque`.
     pub fn push_front(deque: &mut VecDeque<Value>, value: Value) {
         deque.push_front(value);
     }
 
+    /// Appends the `value` to the end of the `deque`.
     pub fn push_back(deque: &mut VecDeque<Value>, value: Value) {
         deque.push_back(value);
     }
 
+    /// Removes and returns the first element of the `deque`.
     pub fn pop_front(deque: &mut VecDeque<Value>) -> anyhow::Result<Value> {
         deque
             .pop_front()
             .ok_or_else(|| anyhow::anyhow!("the queue is empty"))
     }
 
+    /// Removes and returns the first element of the `deque` as an `Option` returning `None` if the queue is empty.
     #[function(name = "pop_front?")]
     pub fn maybe_pop_front(deque: &mut VecDeque<Value>) -> Value {
         deque.pop_front().map_or_else(Value::none, Value::some)
     }
 
+    /// Removes and returns the last element of the `deque`.
     pub fn pop_back(deque: &mut VecDeque<Value>) -> anyhow::Result<Value> {
         deque
             .pop_back()
             .ok_or_else(|| anyhow::anyhow!("the queue is empty"))
     }
 
+    /// Removes and returns the last element of the `deque` as an `Option` returning `None` if the queue is empty.
     #[function(name = "pop_back?")]
     pub fn maybe_pop_back(deque: &mut VecDeque<Value>) -> Value {
         deque.pop_back().map_or_else(Value::none, Value::some)
     }
 
+    /// Returns (but does not remove) the first element of the `deque`.
     pub fn front(deque: &VecDeque<Value>) -> anyhow::Result<Value> {
         deque
             .front()
@@ -50,11 +60,13 @@ mod inner {
             .ok_or_else(|| anyhow::anyhow!("the queue is empty"))
     }
 
+    /// Returns (but does not remove) the first element of the `deque` as an `Option` returning `None` if the queue is empty.
     #[function(name = "front?")]
     pub fn maybe_front(deque: &VecDeque<Value>) -> Value {
         deque.front().cloned().map_or_else(Value::none, Value::some)
     }
 
+    /// Returns (but does not remove) the last element of the `deque`.
     pub fn back(deque: &VecDeque<Value>) -> anyhow::Result<Value> {
         deque
             .back()
@@ -62,16 +74,25 @@ mod inner {
             .ok_or_else(|| anyhow::anyhow!("the queue is empty"))
     }
 
+    /// Returns (but does not remove) the last element of the `deque` as an `Option` returning `None` if the queue is empty.
     #[function(name = "back?")]
     pub fn maybe_back(deque: &VecDeque<Value>) -> Value {
         deque.back().cloned().map_or_else(Value::none, Value::some)
     }
 
-    pub fn contains(deque: &VecDeque<Value>, val: &Value) -> bool {
-        deque.contains(val)
+    /// Returns `true` if the `deque` contains the `value` or `false` otherwise.
+    pub fn contains(deque: &VecDeque<Value>, value: &Value) -> bool {
+        deque.contains(value)
     }
 
+    /// Returns `true` if the `deque` is empty and `false` otherwise.
     pub fn is_empty(deque: &VecDeque<Value>) -> bool {
         deque.is_empty()
+    }
+
+    /// Removes all elements from the `deque`
+    pub fn clear(deque: &mut VecDeque<Value>) -> Value {
+        deque.clear();
+        Value::unit()
     }
 }

--- a/ndc_lib/src/stdlib/file.rs
+++ b/ndc_lib/src/stdlib/file.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::interpreter::environment::Environment;
 use crate::interpreter::function::{
-    Function, FunctionCallError, FunctionCarrier, ParamType, TypeSignature,
+    FunctionBody, FunctionCallError, FunctionCarrier, ParamType, TypeSignature,
 };
 use crate::interpreter::sequence::Sequence;
 use crate::interpreter::value::{Value, ValueType};
@@ -13,7 +13,7 @@ use crate::interpreter::value::{Value, ValueType};
 pub fn register(env: &mut Environment) {
     env.declare(
         "print",
-        Value::from(Function::GenericFunction {
+        Value::function(FunctionBody::GenericFunction {
             function: |args, env| {
                 env.borrow_mut()
                     .with_output(|output| {
@@ -36,7 +36,7 @@ pub fn register(env: &mut Environment) {
 
     env.declare(
         "dbg",
-        Value::from(Function::GenericFunction {
+        Value::function(FunctionBody::GenericFunction {
             function: |args, env| {
                 env.borrow_mut()
                     .with_output(|output| {
@@ -58,7 +58,7 @@ pub fn register(env: &mut Environment) {
     );
     env.declare(
         "read_file",
-        Value::from(Function::GenericFunction {
+        Value::function(FunctionBody::GenericFunction {
             function: |args, _env| match args {
                 [Value::Sequence(Sequence::String(s))] => {
                     read_to_string(Path::new(s.borrow().as_str()))

--- a/ndc_lib/src/stdlib/file.rs
+++ b/ndc_lib/src/stdlib/file.rs
@@ -5,7 +5,7 @@ use std::rc::Rc;
 
 use crate::interpreter::environment::Environment;
 use crate::interpreter::function::{
-    FunctionBody, FunctionCallError, FunctionCarrier, ParamType, TypeSignature,
+    FunctionBody, FunctionCallError, FunctionCarrier, ParamType, Parameter, TypeSignature,
 };
 use crate::interpreter::sequence::Sequence;
 use crate::interpreter::value::{Value, ValueType};
@@ -78,7 +78,10 @@ pub fn register(env: &mut Environment) {
                 }
                 .into()),
             },
-            type_signature: TypeSignature::Exact(vec![ParamType::String]),
+            type_signature: TypeSignature::Exact(vec![Parameter::new(
+                "file_name",
+                ParamType::String,
+            )]),
         }),
     );
 }

--- a/ndc_lib/src/stdlib/file.rs
+++ b/ndc_lib/src/stdlib/file.rs
@@ -1,87 +1,78 @@
-use std::cell::RefCell;
-use std::fs::read_to_string;
-use std::path::Path;
-use std::rc::Rc;
-
 use crate::interpreter::environment::Environment;
-use crate::interpreter::function::{
-    FunctionBody, FunctionCallError, FunctionCarrier, ParamType, Parameter, TypeSignature,
-};
-use crate::interpreter::sequence::Sequence;
-use crate::interpreter::value::{Value, ValueType};
+use crate::interpreter::function::{FunctionBody, FunctionBuilder, FunctionCarrier, TypeSignature};
+use crate::interpreter::value::Value;
+use ndc_macros::export_module;
+use std::fs::read_to_string;
 
-pub fn register(env: &mut Environment) {
+#[export_module]
+mod inner {
+    use anyhow::Context;
+    use std::path::PathBuf;
+
+    pub fn read_file(file_path: &str) -> anyhow::Result<String> {
+        read_to_string(file_path.parse::<PathBuf>().context("invalid file path")?)
+            .context("failed to read file")
+    }
+}
+
+pub fn register_variadic(env: &mut Environment) {
     env.declare(
         "print",
-        Value::function(FunctionBody::GenericFunction {
-            function: |args, env| {
-                env.borrow_mut()
-                    .with_output(|output| {
-                        let mut iter = args.iter().peekable();
-                        while let Some(arg) = iter.next() {
-                            if iter.peek().is_some() {
-                                write!(output, "{arg} ")?;
-                            } else {
-                                writeln!(output, "{arg}")?;
-                            }
-                        }
-                        Ok(())
-                    })
-                    .map_err(|err| FunctionCarrier::IntoEvaluationError(Box::new(err)))?;
-                Ok(Value::unit())
-            },
-            type_signature: TypeSignature::Variadic,
-        }),
+        Value::function(
+            FunctionBuilder::default()
+                .name("print".to_string())
+                .documentation("Print the value.".to_string())
+                .body(FunctionBody::GenericFunction {
+                    function: |args, env| {
+                        env.borrow_mut()
+                            .with_output(|output| {
+                                let mut iter = args.iter().peekable();
+                                while let Some(arg) = iter.next() {
+                                    if iter.peek().is_some() {
+                                        write!(output, "{arg} ")?;
+                                    } else {
+                                        writeln!(output, "{arg}")?;
+                                    }
+                                }
+                                Ok(())
+                            })
+                            .map_err(|err| FunctionCarrier::IntoEvaluationError(Box::new(err)))?;
+                        Ok(Value::unit())
+                    },
+                    type_signature: TypeSignature::Variadic,
+                })
+                .build()
+                .expect("function definition defined in code must be valid"),
+        ),
     );
 
     env.declare(
         "dbg",
-        Value::function(FunctionBody::GenericFunction {
-            function: |args, env| {
-                env.borrow_mut()
-                    .with_output(|output| {
-                        let mut iter = args.iter().peekable();
-                        while let Some(arg) = iter.next() {
-                            if iter.peek().is_some() {
-                                write!(output, "{arg:?} ")?;
-                            } else {
-                                writeln!(output, "{arg:?}")?;
-                            }
-                        }
-                        Ok(())
-                    })
-                    .map_err(|err| FunctionCarrier::IntoEvaluationError(Box::new(err)))?;
-                Ok(Value::unit())
-            },
-            type_signature: TypeSignature::Variadic,
-        }),
-    );
-    env.declare(
-        "read_file",
-        Value::function(FunctionBody::GenericFunction {
-            function: |args, _env| match args {
-                [Value::Sequence(Sequence::String(s))] => {
-                    read_to_string(Path::new(s.borrow().as_str()))
-                        .map(|contents| {
-                            Value::Sequence(Sequence::String(Rc::new(RefCell::new(contents))))
-                        })
-                        .map_err(|err| FunctionCarrier::IntoEvaluationError(Box::new(err)))
-                }
-                [value] => Err(FunctionCallError::ArgumentTypeError {
-                    expected: ValueType::String,
-                    actual: ValueType::from(&*value),
-                }
-                .into()),
-                args => Err(FunctionCallError::ArgumentCountError {
-                    expected: 1,
-                    actual: args.len(),
-                }
-                .into()),
-            },
-            type_signature: TypeSignature::Exact(vec![Parameter::new(
-                "file_name",
-                ParamType::String,
-            )]),
-        }),
+        Value::function(
+            FunctionBuilder::default()
+                .name("dbg".to_string())
+                .documentation("Prints the values for quick and dirty debugging (using the value's debug representation).".to_string())
+                .body(FunctionBody::GenericFunction {
+                    function: |args, env| {
+                        env.borrow_mut()
+                            .with_output(|output| {
+                                let mut iter = args.iter().peekable();
+                                while let Some(arg) = iter.next() {
+                                    if iter.peek().is_some() {
+                                        write!(output, "{arg:?} ")?;
+                                    } else {
+                                        writeln!(output, "{arg:?}")?;
+                                    }
+                                }
+                                Ok(())
+                            })
+                            .map_err(|err| FunctionCarrier::IntoEvaluationError(Box::new(err)))?;
+                        Ok(Value::unit())
+                    },
+                    type_signature: TypeSignature::Variadic,
+                })
+                .build()
+                .expect("function definition defined in code must be valid"),
+        ),
     );
 }

--- a/ndc_lib/src/stdlib/hash_map.rs
+++ b/ndc_lib/src/stdlib/hash_map.rs
@@ -7,30 +7,48 @@ use std::rc::Rc;
 
 #[ndc_macros::export_module]
 mod inner {
-    // TODO: this function makes a copy when returning some kind of iterator would be better
+    /// Returns a list of all the keys in the map or set.
+    ///
+    /// Note that for a set this will return the values in the set.
     pub fn keys(map: &mut HashMap<Value, Value>) -> Value {
         map.keys().cloned().collect::<Vec<_>>().into()
     }
 
-    // TODO: this function makes a copy when returning some kind of iterator would be better
+    /// Returns a list of all the values in the map.
+    ///
+    /// Note that for sets this will return a list of unit types, you should use keys if you want the values in the set.
     pub fn values(map: &mut HashMap<Value, Value>) -> Value {
         map.values().cloned().collect::<Vec<_>>().into()
     }
 
+    /// Removes a key from the map or a value from a set.
     pub fn remove(map: &mut HashMap<Value, Value>, key: &Value) {
         map.remove(key);
     }
 
+    /// Removes all keys from the `left` map/set that are present in the `right` map/set.
+    #[function(name = "remove")]
+    pub fn remove_map(left: &mut HashMap<Value, Value>, right: &HashMap<Value, Value>) {
+        for (key, _) in right {
+            left.remove(key);
+        }
+    }
+
+    /// Insert a value into a map.
     #[function(name = "insert")]
     pub fn insert_map(map: &mut HashMap<Value, Value>, key: Value, value: Value) {
         map.insert(key, value);
     }
 
+    /// Inserts a value into a set.
     #[function(name = "insert")]
     pub fn insert_set(map: &mut HashMap<Value, Value>, key: Value) {
         map.insert(key, Value::unit());
     }
 
+    /// Returns the union (elements that are in either `left` or `right`) of two maps or sets.
+    ///
+    /// This is the same as evaluating the expression `left | right`
     pub fn union(left: DefaultMap<'_>, right: &HashMap<Value, Value>) -> Value {
         Value::Sequence(Sequence::Map(
             Rc::new(RefCell::new(hash_map::union(left.0, right))),
@@ -38,6 +56,9 @@ mod inner {
         ))
     }
 
+    /// Returns the intersection (elements that are in both `left and `right`) of two maps or sets.
+    ///
+    /// This is the same as evaluating the expression `left & right`.
     pub fn intersection(left: DefaultMap<'_>, right: &HashMap<Value, Value>) -> Value {
         Value::Sequence(Sequence::Map(
             Rc::new(RefCell::new(hash_map::intersection(left.0, right))),
@@ -45,6 +66,9 @@ mod inner {
         ))
     }
 
+    /// Returns the symmetric difference (elements that are either in `left` or `right` but not both) of two maps or sets.
+    ///
+    /// This is the same as evaluating the expression `left ~ right`.
     pub fn symmetric_difference(left: DefaultMap<'_>, right: &HashMap<Value, Value>) -> Value {
         Value::Sequence(Sequence::Map(
             Rc::new(RefCell::new(hash_map::symmetric_difference(left.0, right))),
@@ -52,6 +76,7 @@ mod inner {
         ))
     }
 
+    /// Converts the given sequence to set.
     pub fn set(seq: &mut Sequence) -> Value {
         let out: HashMap<Value, Value> = match seq {
             Sequence::String(rc) => rc
@@ -59,7 +84,6 @@ mod inner {
                 .chars()
                 .map(|c| (c.into(), Value::unit()))
                 .collect(),
-            // TODO: we could change the implementation so that ref counts of 1 are consumed instead of copied
             Sequence::List(rc) => rc
                 .borrow()
                 .iter()

--- a/ndc_lib/src/stdlib/math.rs
+++ b/ndc_lib/src/stdlib/math.rs
@@ -181,7 +181,9 @@ mod inner {
 
 pub mod f64 {
     use super::{Environment, Number, ToPrimitive, f64};
-    use crate::interpreter::function::{FunctionBody, FunctionCallError, ParamType, TypeSignature};
+    use crate::interpreter::function::{
+        FunctionBody, FunctionCallError, ParamType, Parameter, TypeSignature,
+    };
     use crate::interpreter::int::Int;
     use crate::interpreter::sequence::Sequence;
     use crate::interpreter::value::Value;
@@ -259,7 +261,7 @@ pub mod f64 {
                     }
                         .into()),
                 },
-                type_signature: TypeSignature::Exact(vec![ParamType::Any]),
+                type_signature: TypeSignature::Exact(vec![Parameter::new("val", ParamType::Any)]),
             }),
         );
     }

--- a/ndc_lib/src/stdlib/math.rs
+++ b/ndc_lib/src/stdlib/math.rs
@@ -182,7 +182,7 @@ mod inner {
 pub mod f64 {
     use super::{Environment, Number, ToPrimitive, f64};
     use crate::interpreter::function::{
-        FunctionBody, FunctionCallError, ParamType, Parameter, TypeSignature,
+        FunctionBody, FunctionBuilder, FunctionCallError, ParamType, Parameter, TypeSignature,
     };
     use crate::interpreter::int::Int;
     use crate::interpreter::sequence::Sequence;
@@ -193,19 +193,22 @@ pub mod f64 {
         macro_rules! delegate_to_f64 {
             ($method:ident,$docs:literal) => {
                 let function = $crate::interpreter::value::Value::function(
-                    $crate::interpreter::function::Function::new_with_docs(
-                        $crate::interpreter::function::FunctionBody::SingleNumberFunction {
-                            body: |num: Number| match num {
-                                Number::Int(i) => Number::Float(f64::from(i).$method()),
-                                Number::Float(f) => Number::Float(f.$method()),
-                                Number::Rational(r) => {
-                                    Number::Float(r.to_f64().unwrap_or(f64::NAN).$method())
-                                }
-                                Number::Complex(c) => Number::Complex(c.$method()),
+                    FunctionBuilder::default()
+                        .body(
+                            $crate::interpreter::function::FunctionBody::SingleNumberFunction {
+                                body: |num: Number| match num {
+                                    Number::Int(i) => Number::Float(f64::from(i).$method()),
+                                    Number::Float(f) => Number::Float(f.$method()),
+                                    Number::Rational(r) => {
+                                        Number::Float(r.to_f64().unwrap_or(f64::NAN).$method())
+                                    }
+                                    Number::Complex(c) => Number::Complex(c.$method()),
+                                },
                             },
-                        },
-                        String::from($docs),
-                    ),
+                        )
+                        .documentation(String::from($docs))
+                        .build()
+                        .unwrap(),
                 );
                 env.declare(stringify!($method), function);
             };

--- a/ndc_lib/src/stdlib/math.rs
+++ b/ndc_lib/src/stdlib/math.rs
@@ -55,22 +55,30 @@ mod inner {
     use anyhow::{Context, anyhow};
     use num::{BigInt, BigRational, BigUint, Integer, complex::Complex64};
 
+    /// Returns the sign of a number.
+    ///
+    /// For `int`, `float`, and `rational` types, this function returns `-1` if the number is negative, `0` if zero, and `1` if positive.
+    /// For complex numbers, it returns the number divided by its magnitude (`z / |z|`) if non-zero, or `0` if the number is `0`.
     pub fn signum(n: &Number) -> Number {
         n.signum()
     }
 
+    /// Returns the real part of a complex number.
     pub fn real(c: Complex64) -> f64 {
         c.re
     }
 
+    /// Returns the imaginary part of a complex number.
     pub fn imag(c: Complex64) -> f64 {
         c.im
     }
 
+    /// Returns the numerator of a rational number.
     pub fn numerator(r: &BigRational) -> BigInt {
         r.numer().clone()
     }
 
+    /// Returns the denominator of a rational number.
     pub fn denominator(r: &BigRational) -> BigInt {
         r.denom().clone()
     }

--- a/ndc_lib/src/stdlib/math.rs
+++ b/ndc_lib/src/stdlib/math.rs
@@ -208,7 +208,9 @@ pub mod f64 {
                         )
                         .documentation(String::from($docs))
                         .build()
-                        .unwrap(),
+                        .expect(
+                            "expected delegate_to_f64 to always create function object correctly",
+                        ),
                 );
                 env.declare(stringify!($method), function);
             };

--- a/ndc_lib/src/stdlib/rand.rs
+++ b/ndc_lib/src/stdlib/rand.rs
@@ -19,15 +19,24 @@ pub fn random_n<N: SampleUniform + std::fmt::Display + Copy>(
 
 #[export_module]
 mod inner {
+    use crate::interpreter::iterator::mut_seq_to_iterator;
     use crate::interpreter::num::Number;
+    use crate::interpreter::sequence::Sequence;
     use crate::interpreter::value::Value;
+    use itertools::Itertools;
 
+    /// Randomly shuffles the elements of the list in place.
     pub fn shuffle(list: &mut [Value]) {
         list.shuffle(&mut rand::rng());
     }
 
-    pub fn shuffled(list: &[Value]) -> Vec<Value> {
-        list.to_vec().tap_mut(|v| v.shuffle(&mut rand::rng()))
+    /// Returns a copy of the input sequence converted to a list with the elements shuffled in random order.
+    ///
+    /// Note: this currently does consume iterators
+    pub fn shuffled(list: &mut Sequence) -> Vec<Value> {
+        mut_seq_to_iterator(list)
+            .collect_vec()
+            .tap_mut(|v| v.shuffle(&mut rand::rng()))
     }
 
     #[function(name = "randf")]

--- a/ndc_lib/src/stdlib/regex.rs
+++ b/ndc_lib/src/stdlib/regex.rs
@@ -5,19 +5,10 @@ use regex::Regex;
 #[ndc_macros::export_module]
 mod inner {
 
+    /// Extracts all signed integers from the given string.
     pub fn nums(haystack: &str) -> Vec<i64> {
-        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\d+").unwrap());
-
-        RE.captures_iter(haystack)
-            .filter_map(|cap| {
-                let (full, []) = cap.extract();
-                full.parse::<i64>().ok()
-            })
-            .collect()
-    }
-
-    pub fn signed_nums(haystack: &str) -> Vec<i64> {
         static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"-?\d+").unwrap());
+
         RE.captures_iter(haystack)
             .filter_map(|cap| {
                 let (full, []) = cap.extract();
@@ -26,11 +17,24 @@ mod inner {
             .collect()
     }
 
+    /// Extracts all unsigned integers from the given string.
+    pub fn unsigned_nums(haystack: &str) -> Vec<i64> {
+        static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\d+").unwrap());
+        RE.captures_iter(haystack)
+            .filter_map(|cap| {
+                let (full, []) = cap.extract();
+                full.parse::<i64>().ok()
+            })
+            .collect()
+    }
+
+    /// Returns `true` if the string matches the given regular expression.
     pub fn matches(haystack: &str, regex: &str) -> Result<bool, regex::Error> {
         let r = Regex::new(regex)?;
         Ok(r.is_match(haystack))
     }
 
+    /// Returns all capture groups from the first match of the regular expression.
     pub fn captures(haystack: &str, regex: &str) -> Result<Value, regex::Error> {
         let r = Regex::new(regex)?;
 
@@ -48,6 +52,7 @@ mod inner {
         Ok(Value::from(list))
     }
 
+    /// Returns the first capture group from the first match of the regular expression.
     pub fn capture_once(haystack: &str, regex: &str) -> Result<Value, regex::Error> {
         let r = Regex::new(regex)?;
 

--- a/ndc_lib/src/stdlib/sequence.rs
+++ b/ndc_lib/src/stdlib/sequence.rs
@@ -81,6 +81,7 @@ fn try_sort_by<E>(
 mod inner {
     use crate::interpreter::{function::FunctionCarrier, iterator::mut_value_to_iterator};
 
+    /// Returns the highest element in the sequence.
     pub fn max(seq: &Sequence) -> anyhow::Result<Value> {
         match seq {
             Sequence::String(s) => s
@@ -103,6 +104,8 @@ mod inner {
             Sequence::Deque(d) => d.try_borrow()?.iter().try_max(),
         }
     }
+
+    /// Returns the lowest element in the sequence.
     pub fn min(seq: &Sequence) -> anyhow::Result<Value> {
         match seq {
             Sequence::String(s) => s
@@ -126,7 +129,10 @@ mod inner {
         }
     }
 
-    pub fn sort(seq: &Sequence) -> anyhow::Result<Value> {
+    /// Sorts the input sequence in place.
+    ///
+    /// This function only works for strings and lists and will throw errors otherwise.
+    pub fn sort_string(seq: &mut Sequence) -> anyhow::Result<Value> {
         match seq {
             Sequence::String(str) => {
                 let r = &mut *str.borrow_mut();
@@ -146,6 +152,14 @@ mod inner {
         }
     }
 
+    /// Sorts the given sequence using a comparing function in place.
+    ///
+    /// The result of the comparing function is compared to the number `0` to determine the relative ordering such that:
+    /// - for values lower than `0` the first argument is smaller than the second argument
+    /// - for values higher than `0` the first argument is greater than the second argument
+    /// - for values equal to `0` the first argument is equal to the second argument
+    ///
+    /// This function only works for strings and lists and will throw errors otherwise.
     pub fn sort_by(list: &mut Vec<Value>, comp: &Callable<'_>) -> EvaluationResult {
         try_sort_by::<FunctionCarrier>(list, |left, right| {
             let ret = comp.call(&mut [left.clone(), right.clone()])?;
@@ -155,12 +169,19 @@ mod inner {
         Ok(Value::unit())
     }
 
+    /// Returns a sorted copy of the input sequence as a list.
     pub fn sorted(seq: &mut Sequence) -> anyhow::Result<Value> {
         let mut list = mut_seq_to_iterator(seq).collect::<Vec<Value>>();
         try_sort_by(&mut list, Value::try_cmp)?;
         Ok(Value::list(list))
     }
 
+    /// Sorts the given sequence using a comparing function, returning a new list with the elements in the sorted order.
+    ///
+    /// The result of the comparing function is compared to the number `0` to determine the relative ordering such that:
+    /// - for values lower than `0` the first argument is smaller than the second argument
+    /// - for values higher than `0` the first argument is greater than the second argument
+    /// - for values equal to `0` the first argument is equal to the second argument
     pub fn sorted_by(seq: &mut Sequence, comp: &Callable<'_>) -> EvaluationResult {
         let mut list = mut_seq_to_iterator(seq).collect::<Vec<Value>>();
         try_sort_by::<FunctionCarrier>(&mut list, |left, right| {
@@ -171,10 +192,12 @@ mod inner {
         Ok(Value::list(list))
     }
 
+    /// Returns the length of a string in bytes.
     pub fn byte_len(str: &str) -> usize {
         str.len()
     }
 
+    /// Returns the length of the sequence, for strings this returns the number of UTF-8 characters.
     pub fn len(seq: &Sequence) -> anyhow::Result<usize> {
         match seq.length() {
             Some(n) => Ok(n),
@@ -185,6 +208,7 @@ mod inner {
         }
     }
 
+    /// Enumerates the given sequence returning a list of tuples where the first element of the tuple is the index of the element in the input sequence.
     pub fn enumerate(seq: &mut Sequence) -> Value {
         match seq {
             Sequence::String(s) => s
@@ -236,10 +260,12 @@ mod inner {
         }
     }
 
+    /// Reduces/folds the given sequence using the given combining function and a custom initial value.
     pub fn fold(seq: &mut Sequence, initial: Value, function: &Callable<'_>) -> EvaluationResult {
         fold_iterator(mut_seq_to_iterator(seq), initial, function)
     }
 
+    /// Reduces/folds the given sequence using the given combining function.
     pub fn reduce(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         let mut iterator = mut_seq_to_iterator(seq);
         let fst = iterator
@@ -249,6 +275,7 @@ mod inner {
         fold_iterator(iterator, fst, function)
     }
 
+    /// Filters the given sequence using the `predicate`.
     pub fn filter(seq: &mut Sequence, predicate: &Callable<'_>) -> EvaluationResult {
         let iterator = mut_seq_to_iterator(seq);
         let mut out = Vec::new();
@@ -268,6 +295,7 @@ mod inner {
         Ok(out.into())
     }
 
+    /// Returns the number of elements in the input sequence for which the given `predicate` returns `true`.
     pub fn count(seq: &mut Sequence, predicate: &Callable<'_>) -> EvaluationResult {
         let iterator = mut_seq_to_iterator(seq);
         let mut out = 0;
@@ -285,6 +313,7 @@ mod inner {
         Ok(out.into())
     }
 
+    /// Returns the value of the first element for which the `predicate` is true for the given input sequence.
     pub fn find(seq: &mut Sequence, predicate: &Callable<'_>) -> EvaluationResult {
         let iterator = mut_seq_to_iterator(seq);
         for element in iterator {
@@ -299,6 +328,7 @@ mod inner {
         Err(anyhow!("find did not find anything").into())
     }
 
+    /// Returns the first index of the element for which the `predicate` is true in the input sequence.
     pub fn locate(seq: &mut Sequence, predicate: &Callable<'_>) -> EvaluationResult {
         let iterator = mut_seq_to_iterator(seq);
         for (idx, element) in iterator.enumerate() {
@@ -313,6 +343,7 @@ mod inner {
         Err(anyhow!("find did not find anything").into())
     }
 
+    /// Returns `true` if the `predicate` is true for none of the elements in `seq`.
     pub fn none(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         for item in mut_seq_to_iterator(seq) {
             match function.call(&mut [item])? {
@@ -330,6 +361,7 @@ mod inner {
 
         Ok(Value::Bool(true))
     }
+    /// Returns `true` if the `predicate` is true for all the elements in `seq`.
     pub fn all(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         for item in mut_seq_to_iterator(seq) {
             match function.call(&mut [item])? {
@@ -348,9 +380,10 @@ mod inner {
         Ok(Value::Bool(true))
     }
 
-    pub fn any(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
+    /// Returns `true` if the `predicate` is true for any of the elements in `seq`.
+    pub fn any(seq: &mut Sequence, predicate: &Callable<'_>) -> EvaluationResult {
         for item in mut_seq_to_iterator(seq) {
-            match function.call(&mut [item])? {
+            match predicate.call(&mut [item])? {
                 Value::Bool(true) => return Ok(Value::Bool(true)),
                 Value::Bool(false) => {}
                 v => {
@@ -366,6 +399,7 @@ mod inner {
         Ok(Value::Bool(false))
     }
 
+    /// Applies the function to each element in a sequence returning the result as a list.
     pub fn map(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         let iterator = mut_seq_to_iterator(seq);
         let mut out = Vec::new();
@@ -377,6 +411,7 @@ mod inner {
         Ok(Value::from(out))
     }
 
+    /// Applies a function to each item in a sequence, flattens the resulting sequences, and returns a single combined sequence.
     pub fn flat_map(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         // let iterator = ;
         let mut out = Vec::new();
@@ -385,16 +420,20 @@ mod inner {
             let fnout = function.call(&mut [item])?;
             match fnout {
                 Value::Sequence(mut inner_seq) => {
-                    // TODO: would it be (much?) faster if we iterate over the iterator and append the elements individually?
                     out.extend(mut_seq_to_iterator(&mut inner_seq));
                 }
-                _ => return Err(anyhow!("callable must return a sequence").into()),
+                _ => {
+                    return Err(
+                        anyhow!("callable argument to flat_map must return a sequence").into(),
+                    );
+                }
             }
         }
 
         Ok(Value::from(out))
     }
 
+    /// Returns the first element of the sequence or the `default` value otherwise.
     pub fn first_or(seq: &mut Sequence, default: Value) -> Value {
         let mut iterator = mut_seq_to_iterator(seq);
         if let Some(item) = iterator.next() {
@@ -404,6 +443,7 @@ mod inner {
         }
     }
 
+    /// Returns the first element of the sequence or the return value of the given function.
     pub fn first_or_else(seq: &mut Sequence, default: &Callable<'_>) -> EvaluationResult {
         let mut iterator = mut_seq_to_iterator(seq);
         Ok(if let Some(item) = iterator.next() {
@@ -413,6 +453,7 @@ mod inner {
         })
     }
 
+    /// Returns the `k` sized combinations of the given sequence `seq` as a list of tuples.
     pub fn combinations(seq: &mut Sequence, k: usize) -> Value {
         Value::list(
             mut_seq_to_iterator(seq)
@@ -422,6 +463,7 @@ mod inner {
         )
     }
 
+    /// Returns the `k` sized permutations of the given sequence `seq` as a list of tuples.
     pub fn permutations(seq: &mut Sequence, k: usize) -> Value {
         Value::list(
             mut_seq_to_iterator(seq)
@@ -431,6 +473,7 @@ mod inner {
         )
     }
 
+    //// Returns al prefixes of a sequence, each as a list.
     pub fn prefixes(seq: &mut Sequence) -> Value {
         // Special case for string which is more efficient and doesn't produce lists of characters
         if let Sequence::String(string) = &seq {
@@ -459,6 +502,7 @@ mod inner {
         )
     }
 
+    /// Returns all suffixes of a sequence, each as a list; for strings, returns all trailing substrings.
     pub fn suffixes(seq: &mut Sequence) -> Value {
         // Special case for string which is more efficient and doesn't produce lists of characters
         if let Sequence::String(string) = &seq {
@@ -481,6 +525,7 @@ mod inner {
         )
     }
 
+    /// Transposes a sequence of sequences, turning rows into columns, and returns the result as a list of lists.
     // TODO: right now transposed always produces a list, it probably should produce whatever the input type was (if possible)
     // TODO: this might not be the expected result for sets (since iterators over sets yield tuples)
     pub fn transposed(seq: &mut Sequence) -> EvaluationResult {
@@ -502,17 +547,10 @@ mod inner {
         }
     }
 
-    pub fn pairwise(seq: &mut Sequence) -> Vec<Value> {
-        mut_seq_to_iterator(seq)
-            .collect::<Vec<_>>()
-            .windows(2)
-            .map(Value::tuple)
-            .collect::<Vec<_>>()
-    }
-
-    // TODO: this implementation probably clones a bit more than it needs to, but it's better tol
-    //       have something than nothing
+    /// Return a list of all windows, wrapping back to the first elements when the window would otherwise exceed the length of source list, producing tuples of size 2.
     pub fn circular_tuple_windows(seq: &mut Sequence) -> Vec<Value> {
+        // TODO: this implementation probably clones a bit more than it needs to, but it's better tol
+        //       have something than nothing
         mut_seq_to_iterator(seq)
             .collect::<Vec<_>>()
             .iter()
@@ -521,6 +559,16 @@ mod inner {
             .collect::<Vec<_>>()
     }
 
+    /// Returns a list of all size-2 windows in `seq`.
+    pub fn pairwise(seq: &mut Sequence) -> Vec<Value> {
+        mut_seq_to_iterator(seq)
+            .collect::<Vec<_>>()
+            .windows(2)
+            .map(Value::tuple)
+            .collect::<Vec<_>>()
+    }
+
+    /// Applies a function to each pair of consecutive elements in a sequence and returns the results as a list.
     #[function(name = "pairwise")]
     pub fn pairwise_map(seq: &mut Sequence, function: &Callable<'_>) -> EvaluationResult {
         let main = mut_seq_to_iterator(seq).collect::<Vec<_>>();
@@ -533,14 +581,19 @@ mod inner {
         Ok(Value::list(out))
     }
 
-    pub fn windows(seq: &mut Sequence, size: usize) -> Vec<Value> {
+    /// Returns a list of all contiguous windows of `length` size. The windows overlap. If the `seq` is shorter than size, the iterator returns no values.
+    pub fn windows(seq: &mut Sequence, length: usize) -> Vec<Value> {
         mut_seq_to_iterator(seq)
             .collect::<Vec<Value>>()
-            .windows(size)
+            .windows(length)
             .map(Value::list)
             .collect()
     }
 
+    /// Return a list that represents the powerset of the elements of `seq`.
+    ///
+    /// The powerset of a set contains all subsets including the empty set and the full input set. A powerset has length `2^n` where `n` is the length of the input set.
+    /// Each list produced by this function represents a subset of the elements in the source sequence.
     pub fn subsequences(seq: &mut Sequence) -> Vec<Value> {
         mut_seq_to_iterator(seq)
             .powerset()
@@ -548,15 +601,42 @@ mod inner {
             .collect::<Vec<Value>>()
     }
 
+    /// Return a list that represents the powerset of the elements of `seq` that are exactly `length` long.
     #[function(name = "subsequences")]
-    pub fn subsequences_len(seq: &mut Sequence, size: usize) -> Vec<Value> {
+    pub fn subsequences_len(seq: &mut Sequence, length: usize) -> Vec<Value> {
         mut_seq_to_iterator(seq)
             .powerset()
-            .filter(|x| x.len() == size)
+            .filter(|x| x.len() == length)
             .map(Value::list)
             .collect::<Vec<Value>>()
     }
 
+    /// Computes the Cartesian product of multiple iterables, returning a list of all possible combinations where each combination contains one element from each iterable.
+    ///
+    /// Example:
+    /// ```ndc
+    /// multi_cartesian_product((1..=3, "abc", [true, false]))
+    /// [
+    ///   [1,"a",true],
+    ///   [1,"a",false],
+    ///   [1,"b",true],
+    ///   [1,"b",false],
+    ///   [1,"c",true],
+    ///   [1,"c",false],
+    ///   [2,"a",true],
+    ///   [2,"a",false],
+    ///   [2,"b",true],
+    ///   [2,"b",false],
+    ///   [2,"c",true],
+    ///   [2,"c",false],
+    ///   [3,"a",true],
+    ///   [3,"a",false],
+    ///   [3,"b",true],
+    ///   [3,"b",false],
+    ///   [3,"c",true],
+    ///   [3,"c",false]
+    /// ]
+    /// ```
     pub fn multi_cartesian_product(seq: &mut Sequence) -> anyhow::Result<Value> {
         let mut iterators = Vec::new();
 
@@ -604,9 +684,7 @@ pub mod extra {
             Value::function(
                 FunctionBuilder::default()
                     .name("zip".to_string())
-                    .documentation(r#"Combines multiple sequences (or iterables) into a single sequence of tuples, where the ith tuple contains the ith element from each input sequence. 
-                    
-                        If the input sequences are of different lengths, the resulting sequence is truncated to the length of the shortest input."#.to_string())
+                    .documentation("Combines multiple sequences (or iterables) into a single sequence of tuples, where the ith tuple contains the ith element from each input sequence.\n\nIf the input sequences are of different lengths, the resulting sequence is truncated to the length of the shortest input.".to_string())
                     .body(FunctionBody::generic(
                         crate::interpreter::function::TypeSignature::Variadic,
                         |args, _env| match args {

--- a/ndc_lib/src/stdlib/sequence.rs
+++ b/ndc_lib/src/stdlib/sequence.rs
@@ -593,13 +593,14 @@ pub mod extra {
     use itertools::izip;
 
     use crate::interpreter::{
-        environment::Environment, function::Function, iterator::mut_value_to_iterator, value::Value,
+        environment::Environment, function::FunctionBody, iterator::mut_value_to_iterator,
+        value::Value,
     };
 
     pub fn register(env: &mut Environment) {
         env.declare(
             "zip",
-            Value::from(Function::generic(
+            Value::function(FunctionBody::generic(
                 crate::interpreter::function::TypeSignature::Variadic,
                 |args, _env| match args {
                     [_] => Err(anyhow!("zip must be called with 2 or more arguments").into()),

--- a/ndc_lib/src/stdlib/serde.rs
+++ b/ndc_lib/src/stdlib/serde.rs
@@ -126,10 +126,12 @@ impl TryFrom<JsonValue> for Value {
 mod inner {
     use crate::interpreter::value::Value;
 
+    /// Converts a JSON string to a value
     pub fn json_decode(input: &str) -> anyhow::Result<Value> {
         serde_json::from_str::<JsonValue>(input)?.try_into()
     }
 
+    /// Converts the input value to json
     pub fn json_encode(input: Value) -> anyhow::Result<Value> {
         let v: JsonValue = input.try_into()?;
         Ok(Value::string(v.to_string()))

--- a/ndc_lib/src/stdlib/string.rs
+++ b/ndc_lib/src/stdlib/string.rs
@@ -25,6 +25,7 @@ pub fn join_to_string(list: &mut Sequence, sep: &str) -> anyhow::Result<String> 
 
 #[export_module]
 mod inner {
+    /// Returns the Unicode code point of a 1-length string.
     pub fn ord(string: &str) -> anyhow::Result<i64> {
         if string.chars().count() == 1 {
             return Ok(i64::from(u32::from(string.chars().next().expect(
@@ -35,85 +36,105 @@ mod inner {
         anyhow::bail!("invalid input length")
     }
 
+    /// Returns the character corresponding to the given Unicode code point.
     pub fn chr(num: i64) -> anyhow::Result<String> {
         let num = u32::try_from(num).context("this number is not a valid character")?;
         let char = char::from_u32(num).context("this number is not a valid character")?;
         Ok(String::from(char))
     }
 
+    /// Converts the string to lowercase.
     pub fn to_lower(string: &str) -> String {
         string.to_lowercase()
     }
 
+    /// Converts the string to uppercase.
     pub fn to_upper(string: &str) -> String {
         string.to_uppercase()
     }
 
+    /// Returns `true` if the string is entirely uppercase.
     pub fn is_upper(string: &str) -> bool {
         string.chars().all(char::is_uppercase)
     }
 
+    /// Returns `true` if the string is entirely lowercase.
     pub fn is_lower(string: &str) -> bool {
         string.chars().all(char::is_lowercase)
     }
 
+    /// Returns a new string with the characters reversed.
     pub fn reversed(string: &str) -> String {
         string.chars().rev().collect()
     }
 
+    /// Reverses the string in place.
     pub fn reverse(string: &mut String) {
         *string = string.chars().rev().collect();
     }
 
+    /// Appends `value` to the given string.
     pub fn append(string: &mut String, value: &str) {
         string.push_str(value);
     }
 
+    /// Joins elements of the sequence into a single string using `sep` as the separator.
     pub fn join(list: &mut Sequence, sep: &str) -> anyhow::Result<String> {
         join_to_string(list, sep)
     }
 
+    /// Splits the string into paragraphs, using blank lines as separators.
     pub fn paragraphs(string: &str) -> Vec<String> {
         string.split("\n\n").map(ToString::to_string).collect()
     }
 
+    /// Joins paragraphs into a single string, inserting blank lines between them.
     pub fn unparagraphs(list: &mut Sequence) -> anyhow::Result<String> {
         join_to_string(list, "\n\n")
     }
 
+    /// Splits the string into lines, using newline characters as separators.
     pub fn lines(string: &str) -> Vec<String> {
         string.lines().map(ToString::to_string).collect()
     }
 
+    /// Joins lines into a single string, inserting newline characters between them.
     pub fn unlines(list: &mut Sequence) -> anyhow::Result<String> {
         join_to_string(list, "\n")
     }
 
+    /// Splits the string into words, using whitespace as the separator.
     pub fn words(string: &str) -> Vec<String> {
         string.split_whitespace().map(ToString::to_string).collect()
     }
 
+    /// Joins words into a single string, separating them with spaces.
     pub fn unwords(list: &mut Sequence) -> anyhow::Result<String> {
         join_to_string(list, " ")
     }
 
+    /// Splits the string by whitespace into a list of substrings.
     pub fn split(string: &str) -> Vec<String> {
         string.split_whitespace().map(ToString::to_string).collect()
     }
 
+    /// Returns `true` if `haystack` starts with `pat`.
     pub fn starts_with(haystack: &str, pat: &str) -> bool {
         haystack.starts_with(pat)
     }
 
+    /// Returns `true` if `haystack` ends with `pat`.
     pub fn ends_with(haystack: &str, pat: &str) -> bool {
         haystack.ends_with(pat)
     }
 
+    /// Splits the string using a given pattern as the delimiter.
     #[function(name = "split")]
     pub fn split_with_pattern(string: &str, pattern: &str) -> Vec<String> {
         string.split(pattern).map(ToString::to_string).collect()
     }
 
+    /// Splits the string at the first occurrence of `pattern`, returning a tuple-like value.
     pub fn split_once(string: &str, pattern: &str) -> Value {
         match string.split_once(pattern) {
             Some((fst, snd)) => Value::Sequence(Sequence::Tuple(Rc::new(vec![
@@ -124,6 +145,7 @@ mod inner {
         }
     }
 
+    /// Removes leading and trailing whitespace from the string.
     pub fn trim(string: &str) -> &str {
         string.trim()
     }
@@ -135,23 +157,29 @@ mod inner {
     //     string.trim_matches(pat)
     // }
 
+    /// Removes leading whitespace from the string.
     pub fn trim_start(string: &str) -> &str {
         string.trim_start()
     }
 
+    /// Removes leading occurrences of `pat` from the string.
     #[function(name = "trim_start")]
     pub fn trim_start_matches<'a>(string: &'a str, pat: &str) -> &'a str {
         string.trim_start_matches(pat)
     }
+
+    /// Removes trailing whitespace from the string.
     pub fn trim_end(string: &str) -> &str {
         string.trim_end()
     }
 
+    /// Removes trailing occurrences of `pat` from the string.
     #[function(name = "trim_end")]
     pub fn trim_end_matches<'a>(string: &'a str, pat: &str) -> &'a str {
         string.trim_end_matches(pat)
     }
 
+    /// Returns `true` if the string consists only of digits.
     pub fn is_digit(string: &str) -> anyhow::Result<bool> {
         if string.len() == 1 {
             Ok(string
@@ -164,10 +192,12 @@ mod inner {
         }
     }
 
+    /// Replaces all occurrences of `from` with `to` in `source`.
     pub fn replace(source: &str, from: &str, to: &str) -> String {
         source.replace(from, to)
     }
 
+    /// Returns `true` if the string consists only of digits in the given radix.
     #[function(name = "is_digit")]
     pub fn is_digit_radix(string: &str, radix: i64) -> anyhow::Result<bool> {
         if string.len() == 1 {

--- a/ndc_lib/src/stdlib/value.rs
+++ b/ndc_lib/src/stdlib/value.rs
@@ -17,15 +17,18 @@ mod inner {
         let mut buf = String::new();
 
         for (sig, fun) in func.function.borrow().iter_implementations() {
-            writeln!(
-                buf,
-                "{sig} -> {}",
-                fun.documentation()
-                    .trim()
-                    .lines()
-                    .next()
-                    .unwrap_or_default()
-            )?;
+            let doc_line = fun
+                .documentation()
+                .trim()
+                .lines()
+                .next()
+                .unwrap_or_default();
+
+            if doc_line.is_empty() {
+                writeln!(buf, "{sig}",)?;
+            } else {
+                writeln!(buf, "{sig} -> {}", doc_line)?;
+            }
         }
 
         buf.pop(); // Remove last newline

--- a/ndc_lib/src/stdlib/value.rs
+++ b/ndc_lib/src/stdlib/value.rs
@@ -17,17 +17,16 @@ mod inner {
         let mut buf = String::new();
 
         for (sig, fun) in func.function.borrow().iter_implementations() {
-            let doc_line = fun
-                .documentation()
-                .trim()
-                .lines()
-                .next()
-                .unwrap_or_default();
-
-            if doc_line.is_empty() {
-                writeln!(buf, "{sig}",)?;
+            if fun.name().is_empty() {
+                write!(buf, "fn({sig})")?;
             } else {
-                writeln!(buf, "{sig} -> {}", doc_line)?;
+                write!(buf, "fn {}({sig})", fun.name())?;
+            }
+
+            if !fun.short_documentation().is_empty() {
+                writeln!(buf, " -> {}", fun.short_documentation())?;
+            } else {
+                writeln!(buf)?;
             }
         }
 

--- a/ndc_lib/src/stdlib/value.rs
+++ b/ndc_lib/src/stdlib/value.rs
@@ -1,13 +1,41 @@
 use ndc_macros::export_module;
+use std::fmt::Write;
 
 #[export_module]
 mod inner {
+    use crate::interpreter::function::Callable;
     use crate::interpreter::heap::{MaxHeap, MinHeap};
     use crate::interpreter::sequence::Sequence;
     use crate::interpreter::value::Value;
     use std::cell::RefCell;
     use std::rc::Rc;
 
+    /// Returns the documentation as a string for a given function in Andy C++.
+    ///
+    /// This function takes a function as its argument and returns a string containing its documentation.
+    pub fn docs(func: &Callable<'_>) -> anyhow::Result<String> {
+        let mut buf = String::new();
+
+        for (sig, fun) in func.function.borrow().iter_implementations() {
+            writeln!(
+                buf,
+                "{sig} -> {}",
+                fun.documentation()
+                    .trim()
+                    .lines()
+                    .next()
+                    .unwrap_or_default()
+            )?;
+        }
+
+        buf.pop(); // Remove last newline
+
+        Ok(buf)
+    }
+
+    /// Returns the reference count for the value, if the value is not reference counted it will return 0
+    ///
+    /// Note: this function does increase the ref count by 1
     pub fn ref_count(value: Value) -> usize {
         match value {
             Value::Option(_) | Value::Number(_) | Value::Bool(_) => 0,
@@ -24,24 +52,31 @@ mod inner {
             Value::Function(r) => Rc::strong_count(&r),
         }
     }
+
+    /// Creates a new instance of `Some`
     #[function(name = "Some")] // <-- fake type constructor
     pub fn some(value: Value) -> Value {
         Value::Option(Some(Box::new(value)))
     }
 
+    /// Creates a new instance of `None`
     pub fn none() -> Value {
         Value::Option(None)
     }
 
+    /// Returns true if the argument is Some<T>
     pub fn is_some(value: &Value) -> Value {
         Value::Bool(matches!(value, Value::Option(Some(_))))
     }
 
+    /// Returns true if the argument is None
     pub fn is_none(value: &Value) -> Value {
         Value::Bool(matches!(value, Value::Option(None)))
     }
 
-    // TODO: this signature should be Option
+    /// Extracts the value from an Option or errors if it's either None or a non-Option type
+    ///
+    /// Note: this function should take an Option as parameter
     pub fn unwrap(value: Value) -> anyhow::Result<Value> {
         match value {
             Value::Option(Some(val)) => Ok(*val),
@@ -52,6 +87,7 @@ mod inner {
         }
     }
 
+    /// Returns a shallow copy of the given value.
     pub fn clone(value: &Value) -> Value {
         match value {
             Value::Option(o) => Value::Option(o.clone()),
@@ -82,6 +118,7 @@ mod inner {
         }
     }
 
+    /// Returns a deep copy of the given value, duplicating all nested structures.
     pub fn deepcopy(value: &Value) -> Value {
         value.deepcopy()
     }

--- a/ndc_lib/src/stdlib/value.rs
+++ b/ndc_lib/src/stdlib/value.rs
@@ -16,7 +16,7 @@ mod inner {
     pub fn docs(func: &Callable<'_>) -> anyhow::Result<String> {
         let mut buf = String::new();
 
-        for (sig, fun) in func.function.borrow().iter_implementations() {
+        for (sig, fun) in func.function.borrow().implementations() {
             if fun.name().is_empty() {
                 write!(buf, "fn({sig})")?;
             } else {

--- a/ndc_macros/src/function.rs
+++ b/ndc_macros/src/function.rs
@@ -186,15 +186,19 @@ fn wrap_single(
     };
 
     let function_registration = quote! {
-        env.declare_function(#register_as_function_name, crate::interpreter::function::Function::new_with_docs(
-            crate::interpreter::function::FunctionBody::GenericFunction {
+        let func = crate::interpreter::function::FunctionBuilder::default()
+            .body(crate::interpreter::function::FunctionBody::GenericFunction {
                 function: #identifier,
                 type_signature: crate::interpreter::function::TypeSignature::Exact(vec![
                     #( crate::interpreter::function::Parameter::new(#param_names, #param_types,) ),*
                 ]),
-            },
-            String::from(#docs),
-        ));
+            })
+            .name(String::from(#register_as_function_name))
+            .documentation(String::from(#docs))
+            .build()
+            .unwrap();
+
+        env.declare_function(#register_as_function_name, func);
     };
 
     WrappedFunction {

--- a/ndc_macros/src/function.rs
+++ b/ndc_macros/src/function.rs
@@ -196,7 +196,7 @@ fn wrap_single(
             .name(String::from(#register_as_function_name))
             .documentation(String::from(#docs))
             .build()
-            .unwrap();
+            .expect("expected function creation in proc macro to always succeed");
 
         env.declare_function(#register_as_function_name, func);
     };

--- a/ndc_macros/src/function.rs
+++ b/ndc_macros/src/function.rs
@@ -6,7 +6,6 @@ use itertools::Itertools;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use std::fmt::Write;
-use syn::spanned::Spanned;
 
 pub struct WrappedFunction {
     pub function_declaration: TokenStream,

--- a/tests/src/programs.rs
+++ b/tests/src/programs.rs
@@ -68,7 +68,7 @@ fn run_test(path: PathBuf) -> Result<(), std::io::Error> {
     // For now let's trim end both result and expect to ensure that any trailing line breaks don't cause issues
     print!("Running {path:?}...");
 
-    let mut interpreter = Interpreter::new(Box::<Vec<u8>>::default());
+    let mut interpreter = Interpreter::new(Vec::new());
     let interpreter_result = interpreter.run_str(&program, false);
 
     let program_had_error = interpreter_result.is_err();


### PR DESCRIPTION
Parses documentation from functions defined in rust and adds the to the runtime.

Also adds a `docs` function to return the documentation as a string:

```
λ trim_start.docs
fn(String) -> Removes leading whitespace from the string.
fn(String, String) -> Removes leading occurrences of `pat` from the string.
```

# Todo

- [x] Add names of parameters to the signature