### PR TITLE
🔥 Remove ahash feature flag, hardcode AHash everywhere

### DIFF
--- a/ndc_lib/Cargo.toml
+++ b/ndc_lib/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 version.workspace = true
 
 [dependencies]
-ahash = { workspace = true, optional = true }
+ahash.workspace = true
 anyhow.workspace = true
 derive_more.workspace = true
 derive_builder.workspace = true
@@ -18,6 +18,3 @@ ryu.workspace = true
 self_cell.workspace = true
 thiserror.workspace = true
 
-[features]
-default = ["ahash"]
-ahash = ["dep:ahash"]

--- a/ndc_lib/src/hash_map.rs
+++ b/ndc_lib/src/hash_map.rs
@@ -1,12 +1,5 @@
-#[cfg(feature = "ahash")]
 pub use ahash::AHashMap as HashMap;
-#[cfg(not(feature = "ahash"))]
-pub use std::collections::HashMap;
-
-#[cfg(feature = "ahash")]
 pub use ahash::AHasher as DefaultHasher;
-#[cfg(not(feature = "ahash"))]
-pub use std::hash::DefaultHasher;
 
 use std::hash::Hash;
 

--- a/ndc_stdlib/Cargo.toml
+++ b/ndc_stdlib/Cargo.toml
@@ -21,6 +21,5 @@ md5 = { version = "0.8.0", optional = true }
 sha1 = { version = "0.10.6", optional = true }
 
 [features]
-default = ["ahash", "crypto"]
-ahash = ["ndc_lib/ahash"]
+default = ["crypto"]
 crypto = ["dep:md5", "dep:sha1"]


### PR DESCRIPTION
Having AHash as an optional dependency isn't improving the project or the codebase at all so this PR removes the feature flag and defaults to always using AHash.