### PR TITLE
feat(stdlib): add base64 encode/decode functions 🔐

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "benches"
 version = "0.0.0"
 dependencies = [
@@ -1214,6 +1220,7 @@ name = "ndc_stdlib"
 version = "0.3.0"
 dependencies = [
  "anyhow",
+ "base64",
  "factorial",
  "itertools 0.14.0",
  "md5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ num = "0.4.3"
 once_cell = "1.21.3"
 ordered-float = "5.1.0"
 yansi = { version = "1.0.1", features = ["detect-tty", "detect-env"] }
+base64 = "0.22"
 rand = "0.10.0"
 rand_chacha = "0.10.0"
 regex = "1.12.3"

--- a/ndc_stdlib/Cargo.toml
+++ b/ndc_stdlib/Cargo.toml
@@ -15,6 +15,7 @@ once_cell.workspace = true
 tap.workspace = true
 
 # Optional
+base64 = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
 regex = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
@@ -24,7 +25,8 @@ md5 = { version = "0.8.0", optional = true }
 sha1 = { version = "0.10.6", optional = true }
 
 [features]
-default = ["crypto", "rand", "regex", "serde"]
+default = ["base64", "crypto", "rand", "regex", "serde"]
+base64 = ["dep:base64"]
 crypto = ["dep:md5", "dep:sha1"]
 rand = ["dep:rand"]
 regex = ["dep:regex"]

--- a/ndc_stdlib/src/base64.rs
+++ b/ndc_stdlib/src/base64.rs
@@ -1,0 +1,28 @@
+use ndc_macros::export_module;
+
+#[export_module]
+mod internal {
+    use ::base64::Engine as _;
+
+    /// Encodes a string using standard base64 (RFC 4648).
+    pub fn base64_encode(val: &str) -> String {
+        ::base64::engine::general_purpose::STANDARD.encode(val)
+    }
+
+    /// Decodes a standard base64-encoded string.
+    pub fn base64_decode(val: &str) -> anyhow::Result<String> {
+        let bytes = ::base64::engine::general_purpose::STANDARD.decode(val)?;
+        String::from_utf8(bytes).map_err(anyhow::Error::new)
+    }
+
+    /// Encodes a string using URL-safe base64 without padding (RFC 4648 §5).
+    pub fn base64_url_encode(val: &str) -> String {
+        ::base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(val)
+    }
+
+    /// Decodes a URL-safe base64-encoded string (no padding required).
+    pub fn base64_url_decode(val: &str) -> anyhow::Result<String> {
+        let bytes = ::base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(val)?;
+        String::from_utf8(bytes).map_err(anyhow::Error::new)
+    }
+}

--- a/ndc_stdlib/src/lib.rs
+++ b/ndc_stdlib/src/lib.rs
@@ -15,6 +15,8 @@ pub mod sequence;
 pub mod string;
 pub mod value;
 
+#[cfg(feature = "base64")]
+pub mod base64;
 #[cfg(feature = "crypto")]
 pub mod crypto;
 #[cfg(feature = "rand")]
@@ -26,6 +28,8 @@ pub mod serde;
 
 pub fn register(env: &mut FunctionRegistry<Rc<NativeFunction>>) {
     aoc::register(env);
+    #[cfg(feature = "base64")]
+    base64::register(env);
     cmp::register(env);
     #[cfg(feature = "crypto")]
     crypto::register(env);


### PR DESCRIPTION
## Summary

- Adds `base64_encode` / `base64_decode` for standard base64 (RFC 4648)
- Adds `base64_url_encode` / `base64_url_decode` for URL-safe base64 without padding (equivalent to PHP's `rtrim(strtr(base64_encode($s), '+/', '-_'), '=')`)
- Gated behind a new `base64` feature, enabled by default (same pattern as `crypto`, `rand`, etc.)
- New dependency: `base64 = "0.22"`

## Test plan

- [ ] `base64_encode("hello world")` → `aGVsbG8gd29ybGQ=`
- [ ] `base64_decode("aGVsbG8gd29ybGQ=")` → `hello world`
- [ ] `base64_url_encode("hello world")` → `aGVsbG8gd29ybGQ`
- [ ] `base64_url_decode("aGVsbG8gd29ybGQ")` → `hello world`
- [ ] `base64_decode` returns an error on invalid input

🤖 Generated with [Claude Code](https://claude.com/claude-code)