### PR TITLE
🛡️ fix(interpreter): restore REPL state after VM error

### DIFF
--- a/ndc_bin/src/main.rs
+++ b/ndc_bin/src/main.rs
@@ -125,7 +125,10 @@ impl TryFrom<Command> for Action {
             Command::Run {
                 file: Some(file),
                 options,
-            } => Self::RunFile { path: file, options },
+            } => Self::RunFile {
+                path: file,
+                options,
+            },
             Command::Run { file: None, .. } => Self::StartRepl,
             Command::Lsp { stdio: _ } => Self::RunLsp,
             Command::Disassemble { file } => Self::DisassembleFile(file),
@@ -153,10 +156,7 @@ fn main() -> anyhow::Result<()> {
     let action: Action = cli.command.unwrap_or_default().try_into()?;
 
     match action {
-        Action::RunFile {
-            path,
-            options,
-        } => {
+        Action::RunFile { path, options } => {
             let filename = path
                 .file_name()
                 .and_then(|name| name.to_str())

--- a/ndc_interpreter/src/lib.rs
+++ b/ndc_interpreter/src/lib.rs
@@ -156,8 +156,16 @@ impl Interpreter {
         input: &str,
     ) -> Result<(Value, ExecutionTimings), InterpreterError> {
         let source_id = self.source_db.add(name, input);
+        // Save the analyser state before parsing so we can roll it back if the VM
+        // fails — otherwise the analyser would remember declarations from a line
+        // that never actually ran.
+        let analyser_checkpoint = self.analyser.checkpoint();
         let (expressions, mut timings) = self.parse_and_analyse(input, source_id)?;
-        let (value, vm_timings) = self.interpret_vm(input, expressions.into_iter())?;
+        let vm_result = self.interpret_vm(input, expressions.into_iter());
+        if vm_result.is_err() {
+            self.analyser.restore(analyser_checkpoint);
+        }
+        let (value, vm_timings) = vm_result?;
         timings.compiling = vm_timings.compiling;
         timings.running = vm_timings.running;
         Ok((value, timings))
@@ -247,6 +255,10 @@ impl Interpreter {
             Some((mut vm, checkpoint)) => {
                 let resume_ip = checkpoint.halt_ip();
                 let prev_num_locals = checkpoint.num_locals();
+                // Clone before consuming: we need the old checkpoint to restore
+                // repl_state if the VM errors, so subsequent REPL lines can still
+                // find their locals on the stack.
+                let old_checkpoint = checkpoint.clone();
                 let (code, new_checkpoint) = measure(&mut timings, Phase::Compiling, || {
                     checkpoint.resume(expressions)
                 })?;
@@ -255,7 +267,12 @@ impl Interpreter {
                 {
                     vm.set_source(input);
                 }
-                measure(&mut timings, Phase::Running, || vm.run())?;
+                if let Err(e) = measure(&mut timings, Phase::Running, || vm.run()) {
+                    // Restore the VM so the next resume_from_halt can cleanly
+                    // truncate the stack back to the pre-error locals.
+                    self.repl_state = Some((vm, old_checkpoint));
+                    return Err(InterpreterError::Vm(e));
+                }
                 let result = vm.last_value(new_checkpoint.num_locals());
                 self.repl_state = Some((vm, new_checkpoint));
                 result

--- a/tests/src/repl.rs
+++ b/tests/src/repl.rs
@@ -130,3 +130,42 @@ fn error_does_not_corrupt_state() {
     let out = String::from_utf8(interp.get_output().unwrap()).unwrap();
     assert_eq!(out.trim(), "99");
 }
+
+#[test]
+fn vm_error_does_not_panic_on_subsequent_local_access() {
+    // Regression test for GitHub issue #130.
+    // A VM-level runtime error (wrong argument type) used to drop repl_state,
+    // causing a subsequent GetLocal on an empty stack to panic.
+    let mut interp = {
+        let mut i = Interpreter::capturing();
+        i.configure(ndc_stdlib::register);
+        i
+    };
+    interp.eval("let data = \"a,b,c\\na,b,c\\n\";").unwrap();
+    // lines() expects a String; passing an Int triggers a VM error.
+    assert!(interp.eval("lines(1)").is_err());
+    // Referencing `data` must not panic.
+    let result = interp.eval("data");
+    assert!(
+        result.is_ok(),
+        "referencing 'data' after a VM error should not fail: {result:?}"
+    );
+}
+
+#[test]
+fn vm_error_rolls_back_failed_declaration() {
+    // After a VM error on a `let` declaration, the name must not be in scope.
+    let mut interp = {
+        let mut i = Interpreter::capturing();
+        i.configure(ndc_stdlib::register);
+        i
+    };
+    // lines() expects a String; this fails at the VM level, so `x` is never bound.
+    assert!(interp.eval("let x = lines(1);").is_err());
+    // `x` should not be accessible.
+    let err = interp.eval("x").expect_err("x should not be declared");
+    assert!(
+        format!("{err:?}").contains("has not previously been declared"),
+        "unexpected error: {err:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #130. A VM-level runtime error in the REPL was leaving `repl_state` as `None` and the analyser carrying declarations for a line that never executed. The next line then ran a fresh VM with an empty stack while the analyser still resolved old locals, panicking on `GetLocal(0)` (index out of bounds).

## Changes

- `ndc_interpreter/src/lib.rs`: clone the resume checkpoint before consuming it so `repl_state` can be put back when `vm.run()` fails; also snapshot the analyser before parse/analyse and roll it back on VM error so failed declarations don't leak into later lines.
- `tests/src/repl.rs`: regression tests covering both the panic on subsequent local access and the rollback of a failed `let`.
- `ndc_bin/src/main.rs`: incidental rustfmt of the `Action::RunFile` arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)