### PR TITLE
🪤 fix(parser): handle EOF after augmented `not` without panicking

### DIFF
--- a/ndc_parser/src/parser.rs
+++ b/ndc_parser/src/parser.rs
@@ -167,19 +167,18 @@ impl Parser {
 
         while let Some(token_location) = self.consume_token_if(&extended_valid_tokens) {
             let (invert, operator_token_loc) = if token_location.token == Token::LogicNot {
-                let augmented = self.consume_token_if(valid_tokens).ok_or_else(|| {
-                    Error::text(
-                        format!(
-                            "unexpected token {}",
-                            self.require_current_token()
-                                .expect("there has to be a token")
-                                .token
-                        ),
-                        self.require_current_token()
-                            .expect("must have current token")
-                            .span,
-                    )
-                })?;
+                let augmented = match self.consume_token_if(valid_tokens) {
+                    Some(t) => t,
+                    None => {
+                        return Err(match self.peek_current_token_location() {
+                            Some(current) => Error::text(
+                                format!("unexpected token {}", current.token),
+                                current.span,
+                            ),
+                            None => Error::end_of_input(token_location.span),
+                        });
+                    }
+                };
                 (Some(token_location), augmented)
             } else {
                 (None, token_location)

--- a/tests/proptest/tests/panic.regressions
+++ b/tests/proptest/tests/panic.regressions
@@ -4,3 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
+cc 50438352354e375bdee77e3a649ee19200ed77839b009f4ab76f4a782807be98 # shrinks to program = [2] a not


### PR DESCRIPTION
## Summary

The proptest panic fuzzer (added in #133) found that token streams like `1 not` panic the parser. In `consume_binary_expression_left_associative`, when a `not` token was consumed expecting an augmented operator (e.g. `not in`, `not ==`) and the following token was missing, the error-construction path called `require_current_token().expect("there has to be a token")` — which panics on end-of-input.

## Changes

- `ndc_parser/src/parser.rs`: replace the panicking `require_current_token().expect(...)` calls with a guarded match: emit `Error::text("unexpected token …")` when a current token exists, otherwise `Error::end_of_input` using the `not` token's span.
- `tests/proptest/tests/panic.regressions`: persisted seed that proptest shrunk to `[2] 1 not`, so this case is locked in as a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)