### PR TITLE
🎲 test: load stdlib in panic-fuzz and add lexer-panic proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,8 +1578,10 @@ name = "proptest_tests"
 version = "0.3.0"
 dependencies = [
  "ndc_analyser",
+ "ndc_core",
  "ndc_lexer",
  "ndc_parser",
+ "ndc_stdlib",
  "ndc_vm",
  "num",
  "proptest",

--- a/ndc_core/src/num.rs
+++ b/ndc_core/src/num.rs
@@ -404,6 +404,21 @@ impl Number {
     }
 
     pub fn pow(self, rhs: Self) -> Result<Self, BinaryOperatorError> {
+        // Reject astronomically large integer exponents up front: an exponent
+        // that doesn't fit in u32 would produce a result too large to compute
+        // in finite time. Without this guard, `2 ^ i64::MAX` hangs the VM.
+        const MAX_EXPONENT_BITS: u64 = 32;
+        let too_large = match &rhs {
+            Self::Int(Int::BigInt(b)) => b.magnitude().bits() > MAX_EXPONENT_BITS,
+            Self::Rational(p) if p.is_integer() => p.numer().magnitude().bits() > MAX_EXPONENT_BITS,
+            _ => false,
+        };
+        if too_large {
+            return Err(BinaryOperatorError::new(
+                "exponent too large to compute".to_string(),
+            ));
+        }
+
         Ok(match (self, rhs) {
             // Int vs others
             (Self::Int(p1), Self::Int(p2)) => {

--- a/tests/functional/programs/900_bugs/bug0020_pow_huge_exponent.ndc
+++ b/tests/functional/programs/900_bugs/bug0020_pow_huge_exponent.ndc
@@ -1,0 +1,7 @@
+// Found by the panic.rs proptest fuzzer with stdlib loaded.
+// `2 ^ i128::MAX` would call num::pow::Pow on a multi-billion-bit
+// magnitude, hanging the VM indefinitely. Now bails with an error
+// instead of computing a result that wouldn't fit in any reasonable
+// amount of memory.
+// expect-error: exponent too large
+print(-2 ^ 170141183460469231731687303715884105727)

--- a/tests/proptest/Cargo.toml
+++ b/tests/proptest/Cargo.toml
@@ -5,8 +5,10 @@ version.workspace = true
 
 [dev-dependencies]
 ndc_analyser.workspace = true
+ndc_core.workspace = true
 ndc_lexer.workspace = true
 ndc_parser.workspace = true
+ndc_stdlib.workspace = true
 ndc_vm.workspace = true
 num.workspace = true
 proptest.workspace = true

--- a/tests/proptest/tests/lexer_panic.rs
+++ b/tests/proptest/tests/lexer_panic.rs
@@ -1,0 +1,168 @@
+//! Property-based panic test for the Andy C++ lexer.
+//!
+//! Generates random `String` inputs and pushes them through `Lexer::new(...)`,
+//! draining the iterator. Errors are expected and ignored; only panics,
+//! `unwrap`s, `expect`s, and `unreachable!`s count as failures.
+//!
+//! Each generated input runs in a worker thread with a 500ms timeout. The
+//! lexer always advances by at least one character per `next()` call, so a
+//! genuine hang would indicate a regression — the timeout exists as a
+//! safety net rather than because we expect to hit it.
+//!
+//! Two test functions share `lexer_panic.regressions`:
+//!
+//! * `known_regressions_do_not_panic` runs by default — it generates 0 fresh
+//!   cases and only replays seeds saved in the regressions file, guarding
+//!   against future commits that resurrect a known panic.
+//! * `fuzz_random_strings` is `#[ignore]`d. Opt in with:
+//!
+//!   ```sh
+//!   cargo test -p proptest_tests -- --ignored             # fuzz only
+//!   cargo test -p proptest_tests -- --include-ignored     # regressions + fuzz
+//!   PROPTEST_CASES=100000 cargo test -p proptest_tests -- --ignored
+//!   ```
+
+use ndc_analyser as _;
+use ndc_core as _;
+use ndc_lexer::{Lexer, SourceId};
+use ndc_parser as _;
+use ndc_stdlib as _;
+use ndc_vm as _;
+use num as _;
+use proptest::prelude::*;
+use proptest::test_runner::FileFailurePersistence;
+use std::fmt;
+use std::panic::{self, AssertUnwindSafe};
+use std::sync::Once;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+const PER_CASE_TIMEOUT: Duration = Duration::from_millis(500);
+const MAX_INPUT_LEN: usize = 200;
+
+/// Wrapper around the generated input with a compact `Debug` impl that
+/// shows byte length plus the escaped input, so a failure prints
+/// `[12B] "0r\"\\#"` instead of a wall of escapes.
+#[derive(Clone)]
+struct Source(String);
+
+impl fmt::Debug for Source {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}B] {:?}", self.0.len(), self.0)
+    }
+}
+
+const WORKER_THREAD_NAME: &str = "proptest-lexer-fuzz-worker";
+
+/// Replace the default panic hook with one that stays silent on the named
+/// worker thread but delegates to the original hook everywhere else.
+/// Without this, every shrinking attempt floods stderr with the same
+/// panic message; with it, only the final shrunk failure (resumed on the
+/// test thread) is printed.
+fn install_quiet_panic_hook() {
+    static HOOK: Once = Once::new();
+    HOOK.call_once(|| {
+        let default_hook = panic::take_hook();
+        panic::set_hook(Box::new(move |info| {
+            if thread::current().name() != Some(WORKER_THREAD_NAME) {
+                default_hook(info);
+            }
+        }));
+    });
+}
+
+/// Single character drawn from a weighted union biased toward bytes that
+/// exercise lexer branches:
+///   - delimiters and escape: `"`, `\`, `#`
+///   - raw-string starter and number suffixes: `r`, `i`, `j`
+///   - number prefixes/separators: digits, `0`, `b`, `x`, `o`, `_`, `.`
+///   - identifier and operator chars
+///   - comment starts: `/`, `#`, `!`
+///   - whitespace incl. `\r` and `\n`
+///
+/// The other arms add general ASCII printable and full-range unicode so
+/// multi-byte offset arithmetic gets exercised too.
+fn arb_char() -> impl Strategy<Value = char> {
+    let high_signal: Vec<char> = vec![
+        '"', '\\', '#', 'r', '.', '_', '?', '+', '-', '*', '/', '%', '=', '<', '>', '!', '&', '|',
+        '^', '~', '(', ')', '[', ']', '{', '}', ',', ';', ':', ' ', '\t', '\n', '\r', 'a', 'b',
+        'c', 'f', 'g', 'i', 'j', 'n', 'o', 'x', 'z', '0', '1', '2', '7', '9',
+    ];
+
+    prop_oneof![
+        20 => prop::sample::select(high_signal),
+        // Any ASCII printable, to widen coverage of the single-char token try-from path.
+        4 => (32u32..=126u32).prop_filter_map("ascii printable", char::from_u32),
+        // Full unicode range minus surrogates and out-of-range codepoints.
+        1 => (0u32..=0x10_FFFF).prop_filter_map("valid scalar value", char::from_u32),
+    ]
+}
+
+fn arb_source() -> impl Strategy<Value = Source> {
+    prop::collection::vec(arb_char(), 0..=MAX_INPUT_LEN)
+        .prop_map(|chars| Source(chars.into_iter().collect()))
+}
+
+/// Drain the lexer over `input`. Returns `()` on any error because the
+/// test only cares about panics, not error variants.
+fn run_lexer(input: &str) {
+    for token in Lexer::new(input, SourceId::new(0)) {
+        let _ = token;
+    }
+}
+
+/// Run the lexer in a worker thread with a hard timeout. Both genuine
+/// panics and timeouts propagate to the proptest harness so it can shrink
+/// them.
+fn run_with_timeout(source: Source) {
+    install_quiet_panic_hook();
+    let (tx, rx) = mpsc::channel();
+    thread::Builder::new()
+        .name(WORKER_THREAD_NAME.into())
+        .spawn(move || {
+            let result = panic::catch_unwind(AssertUnwindSafe(|| run_lexer(&source.0)));
+            let _ = tx.send(result);
+        })
+        .expect("spawn worker thread");
+
+    match rx.recv_timeout(PER_CASE_TIMEOUT) {
+        Err(mpsc::RecvTimeoutError::Timeout) => panic!(
+            "lexer did not terminate within {} ms",
+            PER_CASE_TIMEOUT.as_millis()
+        ),
+        Ok(Err(payload)) => panic::resume_unwind(payload),
+        Ok(Ok(())) | Err(mpsc::RecvTimeoutError::Disconnected) => {}
+    }
+}
+
+fn persistence_config(cases: u32, max_shrink_iters: u32) -> ProptestConfig {
+    ProptestConfig {
+        cases,
+        max_shrink_iters,
+        failure_persistence: Some(Box::new(FileFailurePersistence::WithSource("regressions"))),
+        ..ProptestConfig::default()
+    }
+}
+
+proptest! {
+    // cases=0 skips fresh generation; proptest still replays every seed in
+    // `lexer_panic.regressions` before checking the case count, so this
+    // acts as a regression test for known panics.
+    #![proptest_config(persistence_config(0, 0))]
+
+    #[test]
+    fn known_regressions_do_not_panic(source in arb_source()) {
+        run_with_timeout(source);
+    }
+}
+
+proptest! {
+    #![proptest_config(persistence_config(1024, 4096))]
+
+    #[test]
+    #[ignore = "fuzz test; opt-in via `cargo test ... -- --ignored`"]
+    fn fuzz_random_strings(source in arb_source()) {
+        run_with_timeout(source);
+    }
+}

--- a/tests/proptest/tests/panic.regressions
+++ b/tests/proptest/tests/panic.regressions
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 50438352354e375bdee77e3a649ee19200ed77839b009f4ab76f4a782807be98 # shrinks to program = [2] a not
+cc cbd3b7e7a5fd5a359daf75241e22e7853af918aaee0624f0c40acc9581e8cd23 # shrinks to program = [3] -2 ^ 170141183460469231731687303715884105727

--- a/tests/proptest/tests/panic.rs
+++ b/tests/proptest/tests/panic.rs
@@ -27,14 +27,17 @@
 //! will guard against the regression automatically.
 
 use ndc_analyser::{Analyser, ScopeTree};
+use ndc_core::FunctionRegistry;
 use ndc_lexer::{Span, Token, TokenLocation};
 use ndc_parser::Parser;
 use ndc_vm::compiler::Compiler;
-use ndc_vm::{OutputSink, Vm};
+use ndc_vm::value::{Function as VmFunction, Object as VmObject};
+use ndc_vm::{NativeFunction, OutputSink, Value as VmValue, Vm};
 use proptest::prelude::*;
 use proptest::test_runner::FileFailurePersistence;
 use std::fmt;
 use std::panic::{self, AssertUnwindSafe};
+use std::rc::Rc;
 use std::sync::Once;
 use std::sync::mpsc;
 use std::thread;
@@ -207,17 +210,34 @@ fn arb_program() -> impl Strategy<Value = Program> {
     prop::collection::vec(arb_token().prop_map(loc), 0..=MAX_PROGRAM_LEN).prop_map(Program)
 }
 
-/// Drive parser → analyser → compiler → VM. Returns `()` on any error
-/// because the test only cares about panics, not error variants. The
-/// analyser runs against an empty global scope (no stdlib registered);
-/// undefined-identifier failures are expected and silently ignored.
+/// Build a fresh stdlib `FunctionRegistry`. Cannot be cached across worker
+/// threads because `Rc<NativeFunction>` is `!Send`, so we rebuild it once
+/// per case. In release mode this is sub-millisecond; in debug it adds
+/// noticeable overhead but the regression-replay test only triggers it
+/// for failing seeds, and the fuzz test is opt-in.
+fn build_stdlib_registry() -> FunctionRegistry<Rc<NativeFunction>> {
+    let mut registry = FunctionRegistry::default();
+    ndc_stdlib::register(&mut registry);
+    registry
+}
+
+/// Drive parser → analyser → compiler → VM with the stdlib registered, so
+/// the analyser accepts programs that reference built-ins like `print`,
+/// `len`, `sum`, etc. Returns `()` on any error — the test only cares
+/// about panics, not error variants.
 fn run_pipeline(tokens: Vec<TokenLocation>) {
     let mut expressions = match Parser::from_tokens(tokens).parse() {
         Ok(e) => e,
         Err(_) => return,
     };
 
-    let mut analyser = Analyser::from_scope_tree(ScopeTree::from_global_scope(vec![]));
+    let registry = build_stdlib_registry();
+    let scope = registry
+        .iter()
+        .map(|f| (f.name.clone(), f.static_type.clone()))
+        .collect();
+
+    let mut analyser = Analyser::from_scope_tree(ScopeTree::from_global_scope(scope));
     for e in &mut expressions {
         if analyser.analyse(e).is_err() {
             return;
@@ -232,7 +252,18 @@ fn run_pipeline(tokens: Vec<TokenLocation>) {
         Err(_) => return,
     };
 
-    let mut vm = Vm::new(compiled, Vec::new()).with_output(OutputSink::Buffer(Vec::new()));
+    // Globals must be in the same iteration order as the analyser scope
+    // so the global slot indices match.
+    let globals: Vec<VmValue> = registry
+        .iter()
+        .map(|native| {
+            VmValue::Object(Rc::new(VmObject::Function(VmFunction::Native(Rc::clone(
+                native,
+            )))))
+        })
+        .collect();
+
+    let mut vm = Vm::new(compiled, globals).with_output(OutputSink::Buffer(Vec::new()));
     let _ = vm.run();
 }
 


### PR DESCRIPTION
## Summary

- **Stdlib in panic-fuzz**: `tests/proptest/tests/panic.rs` now builds a `FunctionRegistry`, registers the stdlib, and feeds `(name, StaticType)` pairs to the analyser scope plus matching `Vec<VmValue>` (same iteration order so global slots line up) to `Vm::new`. Random programs that reference built-ins (`print`, `len`, …) now reach the analyser/compiler/VM instead of being rejected up front. Registry is rebuilt per case (`Rc<NativeFunction>` is `!Send`); release-mode cost is negligible — 1M cases in ~66s.
- **Lexer-panic proptest**: new `tests/proptest/tests/lexer_panic.rs` mirrors the panic.rs structure (regression-replay default test + `#[ignore]`d fuzz test) but generates random `String` inputs. Char strategy is weighted toward lexer-trigger bytes (`"`, `\`, `#`, `r`, digit prefixes/suffixes, operators, comment starts) plus full unicode for multi-byte offset coverage.
- **`Number::pow` exponent guard**: first 1M-case run with stdlib loaded shrank to `(-2) ^ i128::MAX`, which calls `num::pow::Pow` on a multi-billion-bit magnitude and never returns (the author had flagged this inline in `int.rs:120` but no guard existed). Now bails with `BinaryOperatorError("exponent too large to compute")` when the exponent magnitude exceeds 2^32 bits.
- **Regressions**: `tests/functional/programs/900_bugs/bug0020_pow_huge_exponent.ndc` pins the user-visible error, and the proptest seed in `panic.regressions` guards against the underlying hang.

## Notes for reviewers

- 32-bit exponent ceiling is generous (~4 billion); any realistic exponent is orders of magnitude below this.
- Lexer fuzzer found nothing at 100k cases — currently functions as a regression net rather than a bug source. The setup is in place to escalate (`PROPTEST_CASES`, `MAX_INPUT_LEN`).
- The two test files share helpers (timeout/quiet panic hook); kept them duplicated for now since each test crate file is its own binary. Happy to dedup into a `common/` module if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)