### PR TITLE
fix(lsp): walk all expression variants when collecting hints 🔍

### DIFF
--- a/ndc_lsp/src/features/inlay_hints.rs
+++ b/ndc_lsp/src/features/inlay_hints.rs
@@ -174,4 +174,20 @@ mod tests {
             )
         );
     }
+
+    #[test]
+    fn lambda_inside_call_gets_return_type_inlay() {
+        let info = collect_hints("[1,2,3].map(fn(y) => y / 2.0);");
+        assert!(info.hints.iter().any(
+            |hint| matches!(&hint.label, InlayHintLabel::String(label) if label.starts_with(" -> "))
+        ));
+    }
+
+    #[test]
+    fn lambda_inside_list_literal_gets_return_type_inlay() {
+        let info = collect_hints("let fns = [fn(x) => x + 1];");
+        assert!(info.hints.iter().any(
+            |hint| matches!(&hint.label, InlayHintLabel::String(label) if label.starts_with(" -> "))
+        ));
+    }
 }

--- a/ndc_lsp/src/visitor.rs
+++ b/ndc_lsp/src/visitor.rs
@@ -119,7 +119,59 @@ fn walk_expression(visitor: &mut impl AstVisitor, expr: &ExpressionLocation) {
             }
         }
         Expression::Return { value } => walk_expression(visitor, value),
-        _ => {}
+        Expression::Logical { left, right, .. } => {
+            walk_expression(visitor, left);
+            walk_expression(visitor, right);
+        }
+        Expression::Assignment { l_value, r_value }
+        | Expression::OpAssignment {
+            l_value, r_value, ..
+        } => {
+            walk_lvalue(visitor, l_value, false);
+            walk_expression(visitor, r_value);
+        }
+        Expression::Call {
+            function,
+            arguments,
+        } => {
+            walk_expression(visitor, function);
+            for arg in arguments {
+                walk_expression(visitor, arg);
+            }
+        }
+        Expression::Tuple { values } | Expression::List { values } => {
+            for v in values {
+                walk_expression(visitor, v);
+            }
+        }
+        Expression::Map { values, default } => {
+            for (key, value) in values {
+                walk_expression(visitor, key);
+                if let Some(v) = value {
+                    walk_expression(visitor, v);
+                }
+            }
+            if let Some(d) = default {
+                walk_expression(visitor, d);
+            }
+        }
+        Expression::RangeInclusive { start, end } | Expression::RangeExclusive { start, end } => {
+            if let Some(s) = start {
+                walk_expression(visitor, s);
+            }
+            if let Some(e) = end {
+                walk_expression(visitor, e);
+            }
+        }
+        Expression::Identifier { .. }
+        | Expression::BoolLiteral(_)
+        | Expression::StringLiteral(_)
+        | Expression::Int64Literal(_)
+        | Expression::Float64Literal(_)
+        | Expression::BigIntLiteral(_)
+        | Expression::ComplexLiteral(_)
+        | Expression::Break
+        | Expression::Continue => {}
     }
 }
 
@@ -138,6 +190,9 @@ fn walk_lvalue(visitor: &mut impl AstVisitor, lvalue: &Lvalue, has_annotation: b
                 walk_lvalue(visitor, lv, has_annotation);
             }
         }
-        Lvalue::Index { .. } => {}
+        Lvalue::Index { value, index, .. } => {
+            walk_expression(visitor, value);
+            walk_expression(visitor, index);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- The LSP's `walk_expression` had a `_ => {}` catch-all that skipped `Call`, `List`, `Tuple`, `Map`, `Logical`, `Assignment`, `OpAssignment`, and the range variants — so any lambda nested inside those (e.g. `[1,2,3].map(fn(y) => y / 2.0)`) never fired `on_function_declaration` and lost its return-type inlay hint, even though the analyser had already computed the type.
- Make the match exhaustive so adding a new `Expression` variant produces a compile error instead of silently regressing visitor coverage.
- Walk into `Lvalue::Index { value, index }` for the same reason — its child expressions could also hide a lambda (e.g. `m[f(fn(x) => x)] = 1`).

## Test plan

- [x] `cargo test -p ndc_lsp` — existing inlay-hint tests pass; two new regression tests pass (`lambda_inside_call_gets_return_type_inlay`, `lambda_inside_list_literal_gets_return_type_inlay`).
- [x] `cargo test` — full suite green.
- [x] `cargo fmt`, `cargo clippy -p ndc_lsp` — no new warnings introduced.
- [x] Manual: open `test.ndc` in an editor with the LSP attached; the inner lambda in `[1,2,3].map(fn(y) => y / 2.0)` shows a ` -> Number` inlay hint.

Note: the lambda's return type displays as `Number` (not `Float`) because `y` is unannotated and the analyser LUBs all `/` overloads. Sharpening that result is follow-up work in the analyser/dispatch logic, not in scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)