### PR TITLE
fix(analyser): widen Binding::Dynamic result to Any 🪟

### DIFF
--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -511,15 +511,37 @@ impl Analyser {
             Binding::Resolved(res) => self.scope_tree.get_type(*res).clone(),
 
             Binding::Dynamic(candidates) => {
-                let return_type = candidates
-                    .iter()
-                    .map(|c| self.scope_tree.get_type(*c).clone())
-                    .filter_map(|t| match t {
-                        StaticType::Function { return_type, .. } => Some(*return_type),
-                        _ => None,
-                    })
-                    .reduce(|a, b| a.lub(&b))
-                    .unwrap_or(StaticType::Any);
+                // Mirror the VM's vectorized fallback (see `Vm::try_vectorized_call`):
+                // a binary call on tuple-of-number arguments produces a tuple at
+                // runtime, even though no declared overload returns one. Preserve
+                // that shape so chained ops like `(a - b) * (a - b)` stay on the
+                // dynamic-dispatch path instead of resolving to a numeric overload
+                // that the value doesn't actually fit.
+                let vectorized_return = if argument_types.len() == 2
+                    && argument_types[0].supports_vectorization_with(&argument_types[1])
+                {
+                    let len = match (&argument_types[0], &argument_types[1]) {
+                        (StaticType::Tuple(l), StaticType::Tuple(r)) => l.len().max(r.len()),
+                        (StaticType::Tuple(l), _) => l.len(),
+                        (_, StaticType::Tuple(r)) => r.len(),
+                        _ => unreachable!("supports_vectorization_with requires a tuple side"),
+                    };
+                    Some(StaticType::Tuple(vec![StaticType::Number; len]))
+                } else {
+                    None
+                };
+
+                let return_type = vectorized_return.unwrap_or_else(|| {
+                    candidates
+                        .iter()
+                        .map(|c| self.scope_tree.get_type(*c).clone())
+                        .filter_map(|t| match t {
+                            StaticType::Function { return_type, .. } => Some(*return_type),
+                            _ => None,
+                        })
+                        .reduce(|a, b| a.lub(&b))
+                        .unwrap_or(StaticType::Any)
+                });
 
                 StaticType::Function {
                     parameters: None,

--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -479,42 +479,6 @@ impl Analyser {
         }
     }
 
-    /// Returns the tuple length a vectorized call would produce, if `left` and
-    /// `right` together have a shape the VM's vectorized fallback could handle:
-    /// two equal-length tuples, or one tuple and one scalar. `Any` is treated
-    /// as a potentially-numeric element / scalar — at static-analysis time we
-    /// don't know what it holds, so we stay permissive and let the dynamic
-    /// dispatch decide at runtime.
-    fn maybe_vectorize_len(left: &StaticType, right: &StaticType) -> Option<usize> {
-        fn could_be_number(t: &StaticType) -> bool {
-            t.is_number() || matches!(t, StaticType::Any)
-        }
-        fn tuple_of_potential_numbers(t: &StaticType) -> Option<usize> {
-            match t {
-                StaticType::Tuple(elems)
-                    if !elems.is_empty() && elems.iter().all(could_be_number) =>
-                {
-                    Some(elems.len())
-                }
-                _ => None,
-            }
-        }
-        match (left, right) {
-            (StaticType::Tuple(_), StaticType::Tuple(_)) => {
-                let l = tuple_of_potential_numbers(left)?;
-                let r = tuple_of_potential_numbers(right)?;
-                (l == r).then_some(l)
-            }
-            (StaticType::Tuple(_), other) => {
-                tuple_of_potential_numbers(left).filter(|_| could_be_number(other))
-            }
-            (other, StaticType::Tuple(_)) => {
-                tuple_of_potential_numbers(right).filter(|_| could_be_number(other))
-            }
-            _ => None,
-        }
-    }
-
     fn resolve_function_with_argument_types(
         &mut self,
         ident: &mut ExpressionLocation,
@@ -546,35 +510,18 @@ impl Analyser {
             }
             Binding::Resolved(res) => self.scope_tree.get_type(*res).clone(),
 
-            Binding::Dynamic(candidates) => {
-                // Mirror the VM's vectorized fallback (see `Vm::try_vectorized_call`):
-                // a binary call on a tuple-shaped argument may produce a tuple at
-                // runtime, even though no declared overload returns one. Preserve
-                // that shape so chained ops like `(a - b) * (a - b)` stay on the
-                // dynamic-dispatch path instead of resolving to a numeric overload
-                // that the value doesn't actually fit. `Any` is treated as a
-                // potentially-numeric element so tuples whose elements come from
-                // stdlib natives (which infer to `Any`) are also caught.
-                let vectorized_return = (argument_types.len() == 2)
-                    .then(|| Self::maybe_vectorize_len(&argument_types[0], &argument_types[1]))
-                    .flatten()
-                    .map(|len| StaticType::Tuple(vec![StaticType::Number; len]));
-
-                let return_type = vectorized_return.unwrap_or_else(|| {
-                    candidates
-                        .iter()
-                        .map(|c| self.scope_tree.get_type(*c).clone())
-                        .filter_map(|t| match t {
-                            StaticType::Function { return_type, .. } => Some(*return_type),
-                            _ => None,
-                        })
-                        .reduce(|a, b| a.lub(&b))
-                        .unwrap_or(StaticType::Any)
-                });
-
+            Binding::Dynamic(_) => {
+                // Dispatch is decided at runtime, so we have no sound static bound
+                // on the result. The runtime may pick a declared overload or fall
+                // through to elementwise (vectorized) dispatch, which can produce
+                // a value no declared overload returns — treating the LUB of
+                // declared returns as the result type is unsound and led to issue
+                // #139, where `let diff = a - b` over tuples was inferred as
+                // `Number` and a follow-up `diff * diff` then matched the numeric
+                // overload directly and bypassed dynamic dispatch entirely.
                 StaticType::Function {
                     parameters: None,
-                    return_type: Box::new(return_type),
+                    return_type: Box::new(StaticType::Any),
                 }
             }
         };

--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -479,6 +479,42 @@ impl Analyser {
         }
     }
 
+    /// Returns the tuple length a vectorized call would produce, if `left` and
+    /// `right` together have a shape the VM's vectorized fallback could handle:
+    /// two equal-length tuples, or one tuple and one scalar. `Any` is treated
+    /// as a potentially-numeric element / scalar — at static-analysis time we
+    /// don't know what it holds, so we stay permissive and let the dynamic
+    /// dispatch decide at runtime.
+    fn maybe_vectorize_len(left: &StaticType, right: &StaticType) -> Option<usize> {
+        fn could_be_number(t: &StaticType) -> bool {
+            t.is_number() || matches!(t, StaticType::Any)
+        }
+        fn tuple_of_potential_numbers(t: &StaticType) -> Option<usize> {
+            match t {
+                StaticType::Tuple(elems)
+                    if !elems.is_empty() && elems.iter().all(could_be_number) =>
+                {
+                    Some(elems.len())
+                }
+                _ => None,
+            }
+        }
+        match (left, right) {
+            (StaticType::Tuple(_), StaticType::Tuple(_)) => {
+                let l = tuple_of_potential_numbers(left)?;
+                let r = tuple_of_potential_numbers(right)?;
+                (l == r).then_some(l)
+            }
+            (StaticType::Tuple(_), other) => {
+                tuple_of_potential_numbers(left).filter(|_| could_be_number(other))
+            }
+            (other, StaticType::Tuple(_)) => {
+                tuple_of_potential_numbers(right).filter(|_| could_be_number(other))
+            }
+            _ => None,
+        }
+    }
+
     fn resolve_function_with_argument_types(
         &mut self,
         ident: &mut ExpressionLocation,
@@ -512,24 +548,17 @@ impl Analyser {
 
             Binding::Dynamic(candidates) => {
                 // Mirror the VM's vectorized fallback (see `Vm::try_vectorized_call`):
-                // a binary call on tuple-of-number arguments produces a tuple at
+                // a binary call on a tuple-shaped argument may produce a tuple at
                 // runtime, even though no declared overload returns one. Preserve
                 // that shape so chained ops like `(a - b) * (a - b)` stay on the
                 // dynamic-dispatch path instead of resolving to a numeric overload
-                // that the value doesn't actually fit.
-                let vectorized_return = if argument_types.len() == 2
-                    && argument_types[0].supports_vectorization_with(&argument_types[1])
-                {
-                    let len = match (&argument_types[0], &argument_types[1]) {
-                        (StaticType::Tuple(l), StaticType::Tuple(r)) => l.len().max(r.len()),
-                        (StaticType::Tuple(l), _) => l.len(),
-                        (_, StaticType::Tuple(r)) => r.len(),
-                        _ => unreachable!("supports_vectorization_with requires a tuple side"),
-                    };
-                    Some(StaticType::Tuple(vec![StaticType::Number; len]))
-                } else {
-                    None
-                };
+                // that the value doesn't actually fit. `Any` is treated as a
+                // potentially-numeric element so tuples whose elements come from
+                // stdlib natives (which infer to `Any`) are also caught.
+                let vectorized_return = (argument_types.len() == 2)
+                    .then(|| Self::maybe_vectorize_len(&argument_types[0], &argument_types[1]))
+                    .flatten()
+                    .map(|len| StaticType::Tuple(vec![StaticType::Number; len]));
 
                 let return_type = vectorized_return.unwrap_or_else(|| {
                     candidates

--- a/tests/functional/programs/900_bugs/bug0021_chained_vectorized_tuple_arith.ndc
+++ b/tests/functional/programs/900_bugs/bug0021_chained_vectorized_tuple_arith.ndc
@@ -15,3 +15,15 @@ assert_eq(diff, (-3, -3, -3));
 assert_eq(diff * diff, (9, 9, 9));
 
 assert_eq((a - b) * (a - b), (9, 9, 9));
+
+// Same hazard but the tuple elements are statically `Any`. `id` here erases
+// type information so the tuples below are `Tuple<Any, Any, Any>`; this
+// mirrors what happens with stdlib natives whose `Value` return type infers
+// to `Any`. The vectorization detection must treat `Any` as a potentially-
+// numeric element so chained ops still go through dynamic dispatch.
+fn id(x) -> Any => x;
+let av = (id(1), id(2), id(3));
+let bv = (id(4), id(5), id(6));
+let cv = av - bv;
+assert_eq(cv, (-3, -3, -3));
+assert_eq(cv * cv, (9, 9, 9));

--- a/tests/functional/programs/900_bugs/bug0021_chained_vectorized_tuple_arith.ndc
+++ b/tests/functional/programs/900_bugs/bug0021_chained_vectorized_tuple_arith.ndc
@@ -1,0 +1,17 @@
+// BUG#0021 (issue #139): vectorized tuple arithmetic broke when the result
+// of one tuple op was fed into another. The analyser inferred the result of
+// `a - b` as `Number` (the LUB of the dynamic candidates' return types), so
+// `diff * diff` resolved statically to a `(Number, Number) -> Number`
+// overload via `Binding::Resolved` and bypassed OverloadSet dispatch — and
+// therefore the VM's vectorized fallback. The native then bailed with
+// "expected number, got Tuple<Int, Int, Int>".
+let a = (1, 2, 3);
+let b = (4, 5, 6);
+
+assert_eq(a * b, (4, 10, 18));
+
+let diff = a - b;
+assert_eq(diff, (-3, -3, -3));
+assert_eq(diff * diff, (9, 9, 9));
+
+assert_eq((a - b) * (a - b), (9, 9, 9));


### PR DESCRIPTION
## Summary

Fixes #139. Regression from #131 (the type-annotation work): vectorized tuple arithmetic crashed at runtime whenever the result of one tuple op was fed into another, e.g. `let diff = a - b; diff * diff` or `(a - b) * (a - b)`.

## Root cause

In `resolve_function_with_argument_types`, the `Binding::Dynamic` arm inferred the call's result as the LUB of every candidate's declared return type. That LUB is sound only when one of those candidates is statically guaranteed to fire. With dynamic dispatch the value-level dispatcher can fall through to elementwise / vectorized handling at runtime and produce a value no declared overload returns. So `let diff = a - b` over tuples was inferred as `diff: Number` (the LUB of the numeric overloads), and the follow-up `diff * diff` then exact-matched `(Number, Number) -> Number`, emitted a direct `Call` instead of `OverloadSet` dispatch, and bypassed dynamic dispatch entirely — surfacing as `expected number, got Tuple<Int, Int, Int>` at runtime.

The same hole shows up whenever a `Tuple` flows through dynamic dispatch — e.g. `(id(1), id(2)) - (id(3), id(4))` where `id` returns `Any` — because the analyser still gets back a confident-but-wrong `Number`.

## Fix

Widen the `Binding::Dynamic` arm's result to `StaticType::Any`. Runtime-dispatched calls don't have a sound static bound on their result, so the analyser stops pretending otherwise. Every cascade rung now stays on dynamic dispatch, and the VM's existing value-level dispatcher decides at runtime.

## Changes

- `ndc_analyser/src/analyser.rs` — `Binding::Dynamic` arm returns `Any` instead of LUB-of-candidate-returns. No more special-cased vectorization detection.
- `tests/functional/programs/900_bugs/bug0021_chained_vectorized_tuple_arith.ndc` — regression test covering the original repro from #139 plus a `Tuple<Any, …>` variant (`fn id(x) -> Any => x` to keep the type-erasure independent of stdlib evolution).

## Performance

Acceptable regression — within noise on this machine. `hyperfine --warmup 3 --runs 30`:

| program | before (ms) | after (ms) | ratio |
|---|---|---|---|
| sieve | 112.8 ± 5.7 | 109.1 ± 4.1 | 1.03× faster after |
| matrix_mul | 58.9 ± 4.4 | 58.1 ± 3.8 | 1.01× faster after |
| fibonacci_typed | 57.4 ± 4.5 | 59.1 ± 4.2 | 1.03× slower after |

A smaller 5-run sweep over `fibonacci`, `quicksort`, `hof_pipeline`, `ackermann`, `pi_approx` all landed at 1.00×–1.06× in either direction with σ bigger than the delta.

## Trade-off worth flagging

`Binding::Dynamic` sites lose their LUB-derived inlay hints — e.g. a user-defined function with `(Int) -> Int` and `(Float) -> Float` overloads called via dynamic dispatch used to surface `Number` on the LHS of a `let`, and will now surface `Any` (filtered from inlay hints). The LUB was always a heuristic that happened to look right; the soundness fix removes it. Happy to revisit if the LSP UX hit feels too steep.

🤖 PR description by Claude.