### PR TITLE
perf(vm): borrow callee name in vec dispatch instead of allocating 🪢

### DIFF
--- a/ndc_vm/src/vm.rs
+++ b/ndc_vm/src/vm.rs
@@ -893,12 +893,26 @@ impl Vm {
         debug_assert!(!vec_candidates.is_empty());
 
         let arg_start = self.stack.len() - args;
-        let callee_name = self.callee_name(args);
-
         let arg_values: Vec<Value> = self.stack.split_off(arg_start);
         self.stack.pop(); // discard the callee slot
 
         let frame_pointer = self.frames.last().expect("no frame").frame_pointer;
+
+        // Resolve one candidate up front so the error paths can borrow its name
+        // as `&str` instead of allocating a `String` on every successful call.
+        let callee_fn: Option<Rc<Object>> =
+            vec_candidates
+                .first()
+                .and_then(|var| match self.resolve_var(var, frame_pointer) {
+                    Value::Object(obj) if matches!(obj.as_ref(), Object::Function(_)) => Some(obj),
+                    _ => None,
+                });
+        let callee_name: Option<&str> = callee_fn.as_ref().and_then(|obj| {
+            let Object::Function(f) = obj.as_ref() else {
+                return None;
+            };
+            f.name()
+        });
 
         let mut elem_args: Vec<Value> = Vec::with_capacity(args);
         let mut results: Vec<Value> = Vec::with_capacity(axis_len);
@@ -935,7 +949,7 @@ impl Vm {
                         .map(|v| v.static_type().to_string())
                         .collect::<Vec<_>>()
                         .join(", ");
-                    let name = callee_name.as_deref().unwrap_or("?");
+                    let name = callee_name.unwrap_or("?");
                     return Err(VmError::new(
                         format!("no overload of '{name}' accepts element {i}: ({element_types})"),
                         span,
@@ -946,7 +960,7 @@ impl Vm {
             };
 
             let result = self.call_callback(scalar, &elem_args).map_err(|mut e| {
-                let prefix = match &callee_name {
+                let prefix = match callee_name {
                     Some(name) => format!("while vectorising '{name}' at index {i}: "),
                     None => format!("while vectorising at index {i}: "),
                 };
@@ -973,7 +987,10 @@ impl Vm {
         span: Span,
     ) -> Result<(), VmError> {
         let arg_start = self.stack.len() - args;
-        let callee_name = self.callee_name(args);
+        // Borrow the callee name straight off the resolved scalars — its lifetime
+        // is tied to the caller-owned slice, not to `self`, so the error paths
+        // can use it without allocating a `String` on the success path.
+        let callee_name: Option<&str> = scalars.first().and_then(|f| f.name());
 
         // Materialise the broadcast arguments up front so the inner
         // call_callback can hold &mut self without conflicting with stack
@@ -1017,7 +1034,7 @@ impl Vm {
                         .map(|v| v.static_type().to_string())
                         .collect::<Vec<_>>()
                         .join(", ");
-                    let name = callee_name.as_deref().unwrap_or("?");
+                    let name = callee_name.unwrap_or("?");
                     return Err(VmError::new(
                         format!("no overload of '{name}' accepts element {i}: ({element_types})"),
                         span,
@@ -1028,7 +1045,7 @@ impl Vm {
             };
 
             let result = self.call_callback(scalar, &elem_args).map_err(|mut e| {
-                let prefix = match &callee_name {
+                let prefix = match callee_name {
                     Some(name) => format!("while vectorising '{name}' at index {i}: "),
                     None => format!("while vectorising at index {i}: "),
                 };


### PR DESCRIPTION
## Summary

`dispatch_vec_call` and `dispatch_vec_call_dynamic` both eagerly built an `Option<String>` for the callee's name on every call, then only read it from rarely-taken error branches (the overload-not-found `Err` and the `call_callback` `map_err` closure). The success path threw the `String` away. Same shape of bug as the GetIterator fix in #147.

## Changes

- `dispatch_vec_call`: borrow `&str` directly from `scalars.first().and_then(|f| f.name())`. The slice is a caller-owned parameter, so the borrow lifetime is independent of `&mut self` and the `map_err` closure can capture it freely.
- `dispatch_vec_call_dynamic`: resolve the first vec candidate once into a held `Rc<Object>`, then borrow `&str` out of it. The `resolve_var` call already happened inside the old `callee_name()`; the `.to_string()` is what's gone.
- `Vm::callee_name()` itself is kept — it's still used from the regular `Call` opcode's "no function found" error path, where the allocation is fine because we're already on an error path.

## Caveat — perf impact is barely measurable

`vec_hot_loop` (200k–2M `(int,int) + (int,int)` calls):

| Iters | Baseline | This PR |
|---|---|---|
| 200k | 39.0 ± 3.4 ms | 38.6 ± 3.1 ms |
| 2M | 336.2 ± 3.8 ms | 334.5 ± 4.1 ms |

≈1.01× — within noise. `perf` confirms ~13% of total time goes to malloc/free, but the eliminated allocation is one small `String` (operator name like `"+"`) per outer vec call, dwarfed by `Function::clone`, the per-call `Vec` allocations for `arg_values`/`elem_args`/`results`, and the final `Rc::new(Object::Tuple(...))`. Unlike the GetIterator case, there's no deep recursive walk being saved here.

So this is more of a code-cleanliness/correctness fix (no wasted allocation on the hot path; `&str` reads more naturally than `Option<String>`) than a real perf win. Happy to drop it if you'd rather not carry the churn.

🤖 PR description generated by Claude.