### PR TITLE
perf(vm): lazily clone parent upvalues on Closure 🪺

### DIFF
--- a/ndc_vm/src/vm.rs
+++ b/ndc_vm/src/vm.rs
@@ -498,28 +498,30 @@ impl Vm {
                     // and before `capture_upvalue` needs `&mut self`.
                     let idx = *idx;
                     let values = Rc::clone(values);
-                    let frame = self.frames.last().expect("no frame");
-                    let Value::Object(obj) = frame.closure.prototype.body.constant(idx) else {
-                        panic!("Closure opcode: constant at index {idx} is not an Object");
+                    let (compiled, frame_pointer) = {
+                        let frame = self.frames.last().expect("no frame");
+                        let Value::Object(obj) = frame.closure.prototype.body.constant(idx) else {
+                            panic!("Closure opcode: constant at index {idx} is not an Object");
+                        };
+                        let Object::Function(Function::Compiled(compiled)) = &**obj else {
+                            panic!(
+                                "Closure opcode: constant at index {idx} is not a Compiled function"
+                            );
+                        };
+                        (Rc::clone(compiled), frame.frame_pointer)
                     };
-                    let Object::Function(Function::Compiled(compiled)) = &**obj else {
-                        panic!(
-                            "Closure opcode: constant at index {idx} is not a Compiled function"
-                        );
-                    };
-                    let compiled = Rc::clone(compiled);
-                    let frame_pointer = frame.frame_pointer;
-                    // Pre-clone parent upvalue Rcs so we can drop the frame borrow
-                    // before calling capture_upvalue (which needs &mut self).
-                    let parent_upvalues: Vec<_> =
-                        frame.closure.upvalues.iter().map(Rc::clone).collect();
+                    // Resolve captures lazily: only clone the specific parent upvalue
+                    // Rcs that this closure references, and capture locals on demand.
                     let upvalues = values
                         .iter()
                         .map(|c| match c {
                             CaptureSource::Local(slot) => {
                                 self.capture_upvalue(frame_pointer + slot)
                             }
-                            CaptureSource::Upvalue(slot) => Rc::clone(&parent_upvalues[*slot]),
+                            CaptureSource::Upvalue(slot) => {
+                                let frame = self.frames.last().expect("no frame");
+                                Rc::clone(&frame.closure.upvalues[*slot])
+                            }
                         })
                         .collect();
                     let closure = Value::function(Function::Closure(ClosureFunction {


### PR DESCRIPTION
## Context
A code-review agent flagged `OpCode::Closure` at `ndc_vm/src/vm.rs:514` as wasteful: every closure creation pre-cloned the entire parent frame's `upvalues` Vec, even when the new closure didn't reference any of them. The Vec was only there to outlive the `frame` borrow so that `capture_upvalue` (which needs `&mut self`) could be called.

## Change
Walk `CaptureSource` entries directly and resolve each on demand:
- `Local(slot)` → `self.capture_upvalue(...)` as before
- `Upvalue(slot)` → briefly re-borrow the frame and clone just that one parent upvalue `Rc`

The two borrows never overlap in time, so the borrow checker is happy without the intermediate Vec. Closures that only capture locals now do zero parent-upvalue work.

## Performance
| Bench | Baseline | New | Speedup |
|---|---|---|---|
| Targeted (parent has 16 upvalues, 200k closures) | 215.0 ± 12.3 ms | 200.4 ± 8.8 ms | 1.07× |
| `closures.ndc` (existing, parent has 0 upvalues) | 72.0 ± 3.4 ms | 70.2 ± 3.2 ms | 1.03× (noise) |
| `fibonacci.ndc` (regression check, no closures) | 70.0 ± 2.5 ms | 70.5 ± 3.0 ms | no change |

The existing `closures.ndc` bench doesn't exercise the case this fix targets — the captured closures sit directly under the script root, so the parent's `upvalues` was empty and the old code's pre-clone was `Vec::new()`. The targeted ad-hoc bench (16 parent upvalues × 200k creations) shows the real ~7% win.

A `nested_closures.ndc` bench could be added to track this path going forward — happy to do that as a follow-up if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)