### PR TITLE
fix(ext): make tree-sitter highlighting work in Helix 🚁

### DIFF
--- a/ext/tree-sitter-andy-cpp/README.md
+++ b/ext/tree-sitter-andy-cpp/README.md
@@ -156,17 +156,29 @@ args = ["lsp"]
 
 [[grammar]]
 name = "andy-cpp"
-source = { git = "https://github.com/timfennis/andy-cpp", subpath = "ext/tree-sitter-andy-cpp" }
+# A git source must include `rev`. If you have the repo checked out, a local
+# path is simpler: source = { path = "/abs/path/to/ext/tree-sitter-andy-cpp" }
+source = { git = "https://github.com/timfennis/andy-cpp", rev = "master", subpath = "ext/tree-sitter-andy-cpp" }
 ```
 
-Fetch and build the grammar, then install the queries:
+Build the grammar into Helix's runtime and install the queries. Rather than
+`hx --grammar build` (which rebuilds every grammar and needs the output
+directory to already exist), build just this one with the tree-sitter CLI — the
+output file must be named `andy-cpp.so` to match the grammar name:
 
 ```bash
-hx --grammar fetch
-hx --grammar build
-mkdir -p ~/.config/helix/runtime/queries/andy-cpp
-cp ext/tree-sitter-andy-cpp/queries/*.scm ~/.config/helix/runtime/queries/andy-cpp/
+cd ext/tree-sitter-andy-cpp
+npm install
+mkdir -p ~/.config/helix/runtime/grammars ~/.config/helix/runtime/queries/andy-cpp
+npx tree-sitter build -o ~/.config/helix/runtime/grammars/andy-cpp.so
+cp queries/*.scm ~/.config/helix/runtime/queries/andy-cpp/
 ```
+
+Check it with `hx --health andy-cpp` (Tree-sitter parser, Highlight queries, and
+the `ndc-lsp` server should all be ✓).
+
+> The binary is `hx` in most installs but may be `helix` (e.g. some distro
+> packages); use whichever your install provides.
 
 ## Known limitations
 

--- a/ext/tree-sitter-andy-cpp/queries/injections.scm
+++ b/ext/tree-sitter-andy-cpp/queries/injections.scm
@@ -1,4 +1,6 @@
 ; Highlight the leading `#!...` shebang line as bash.
+; `#match?` (regex) is portable across Neovim and Helix; `#lua-match?` is
+; Neovim-only and breaks Helix's combined query compilation.
 ((comment) @injection.content
-  (#lua-match? @injection.content "^#!")
+  (#match? @injection.content "^#!")
   (#set! injection.language "bash"))


### PR DESCRIPTION
## Context

Follow-up to #165. Setting up the grammar in Helix surfaced two problems (Neovim was unaffected):

1. **No highlighting in Helix.** Helix compiles `highlights` + `injections` + `locals` into one tree-sitter query, so the Neovim-only `#lua-match?` predicate in `injections.scm` failed the *entire* highlight compile (`unknown predicate #lua-match?`). The LSP still worked, which is why it looked like only highlighting was broken.
2. **Broken Helix setup docs.** The README's `[[grammar]]` git source omitted `rev`, producing `data did not match any variant of untagged enum GrammarSource`.

## Changes

- **`injections.scm`**: `#lua-match?` → `#match?`. Both Neovim and Helix support `#match?`, and `^#!` matches identically under each editor's regex. Verified the combined query now compiles via the `tree-sitter highlight` CLI (same `tree-sitter-highlight` crate Helix uses), and that Neovim still loads the query.
- **README Helix section**: git sources now include `rev` (with a local-path alternative), and the build step uses `tree-sitter build -o …/grammars/andy-cpp.so` instead of `hx --grammar build` (which rebuilds every grammar and needs the output dir to pre-exist). Added an `hx --health` check and an `hx`-vs-`helix` binary note.

Capture ordering was checked and left as-is: Helix's own bundled queries place the catch-all `(identifier) @variable` before the specific `@function`/`@variable.parameter` captures, confirming Helix resolves overlaps last-match-wins like Neovim, so the existing ordering is correct for both.

🤖