### PR TITLE
fix(stdlib): return error instead of panicking on windows size 0 🪟

### DIFF
--- a/ndc_stdlib/src/sequence.rs
+++ b/ndc_stdlib/src/sequence.rs
@@ -707,8 +707,10 @@ mod inner {
 
     /// Returns a list of all contiguous windows of `length` size. The windows overlap. If the `seq` is shorter than size, the iterator returns no values.
     #[function(return_type = Vec<_>)]
-    pub fn windows(seq: SeqValue, length: i64) -> anyhow::Result<Value> {
-        let length = length as usize;
+    pub fn windows(seq: SeqValue, length: usize) -> anyhow::Result<Value> {
+        if length == 0 {
+            return Err(anyhow!("window size must be non-zero"));
+        }
         Ok(Value::list(
             seq.try_into_iter()
                 .ok_or_else(|| anyhow!("windows requires a sequence"))?

--- a/tests/functional/programs/900_bugs/bug0024_windows_zero_size.ndc
+++ b/tests/functional/programs/900_bugs/bug0024_windows_zero_size.ndc
@@ -1,0 +1,5 @@
+// `windows(seq, 0)` used to reach `slice::windows(0)`, which panics with
+// "window size must be non-zero". It now returns a graceful error, matching
+// the sibling `chunks` function.
+// expect-error: window size must be non-zero
+windows([1, 2, 3], 0);


### PR DESCRIPTION
## What

`windows(seq, 0)` panicked the VM instead of returning an error:

```
$ echo 'windows([1,2,3], 0)' | ndc
thread 'main' panicked at ndc_stdlib/src/sequence.rs:716:18:
window size must be non-zero
```

The stdlib `windows` function took `length: i64`, cast it to `usize`, and passed it straight to `slice::windows(length)` — which panics when the size is `0`. Negative input was also wrong: it wrapped to a huge `usize` and silently returned `[]`.

The sibling `chunks` function already handles both cases correctly (a `length == 0` guard plus a `usize` parameter so negatives are rejected at argument conversion). This change brings `windows` in line.

## Changes

- `ndc_stdlib/src/sequence.rs`: `windows` now takes `length: usize` and returns an error when `length == 0`. Negatives are now rejected at arg conversion (`arg 1: expected a non-negative integer`), matching `chunks`.
- `tests/functional/programs/900_bugs/bug0024_windows_zero_size.ndc`: regression test asserting the graceful `window size must be non-zero` error.

## Context

Found while hunting for a way to panic the pipeline (lexer → parser → analyser → compiler → VM). The existing token-stream fuzzer never reaches this code because it only generates the identifiers `a,b,c,x,f,g`, so it never calls any stdlib function by name — the whole stdlib surface is outside its reach.

Behaviour unchanged on the happy path: `windows([1,2,3,4], 2)` → `[[1,2],[2,3],[3,4]]`, and a too-short sequence still yields `[]`.

🤖