### PR TITLE
fix(core): promote to BigInt instead of panicking on neg/abs of i64::MIN 💥

### DIFF
--- a/ndc_core/src/int.rs
+++ b/ndc_core/src/int.rs
@@ -149,7 +149,10 @@ impl Int {
     #[must_use]
     pub fn abs(&self) -> Self {
         match self {
-            Self::Int64(i) => Self::from(i.abs()),
+            // `i64::MIN.abs()` overflows, so promote to BigInt in that case.
+            Self::Int64(i) => i
+                .checked_abs()
+                .map_or_else(|| Self::from(BigInt::from(*i).abs()), Self::Int64),
             Self::BigInt(b) => Self::from(b.abs()),
         }
     }
@@ -218,7 +221,10 @@ impl Neg for Int {
 
     fn neg(self) -> Self::Output {
         match self {
-            Self::Int64(i) => Self::Int64(i.neg()),
+            // `-i64::MIN` overflows, so promote to BigInt in that case.
+            Self::Int64(i) => i
+                .checked_neg()
+                .map_or_else(|| Self::BigInt(BigInt::from(i).neg()), Self::Int64),
             Self::BigInt(i) => Self::BigInt(i.neg()),
         }
     }

--- a/tests/functional/programs/001_math/032_neg_abs_i64_min.ndc
+++ b/tests/functional/programs/001_math/032_neg_abs_i64_min.ndc
@@ -1,0 +1,8 @@
+// Negating or taking the absolute value of `i64::MIN` overflows the i64
+// range (`-i64::MIN` does not fit in an i64). `Int::neg` and `Int::abs` used
+// to call `i.neg()` / `i.abs()` directly, which panics in debug builds and
+// silently wraps in release. They now promote to BigInt, yielding the correct
+// positive magnitude.
+// expect-output: 9223372036854775808 9223372036854775808 9223372036854775808
+let min = -9223372036854775807 - 1;
+print(-min, abs(min), abs(-min));

--- a/tests/functional/programs/900_bugs/bug0026_neg_abs_i64_min_overflow.ndc
+++ b/tests/functional/programs/900_bugs/bug0026_neg_abs_i64_min_overflow.ndc
@@ -1,0 +1,6 @@
+// `abs(i64::MIN)` and `-(i64::MIN)` overflow the i64 range because the
+// positive magnitude `2^63` does not fit in an i64. `Int::abs`/`Int::neg`
+// used to evaluate `i.abs()`/`i.neg()` directly, panicking with "attempt to
+// negate with overflow" in debug builds. They now promote to BigInt.
+// expect-output: 9223372036854775808
+print(abs(-9223372036854775807 - 1));


### PR DESCRIPTION
## Context

Continuing the recent sweep of panic-on-edge-case fixes (negative power, `windows` size 0, integer division by zero), I went looking for another arithmetic input that crashes the interpreter. Negating or taking the absolute value of `i64::MIN` does it: the positive magnitude `2^63` does not fit in an `i64`.

```
abs(-9223372036854775807 - 1)   // i64::MIN
```

`Int::abs` and `Int::neg` called `i.abs()` / `i.neg()` directly on the `Int64` variant. Both overflow at `i64::MIN`, panicking with "attempt to negate with overflow" in debug builds and silently wrapping to a negative result in release.

## Changes

- `ndc_core/src/int.rs`: `Int::abs` and `Int::neg` now use `checked_abs` / `checked_neg` and promote to `BigInt` on overflow, matching the checked-then-promote pattern already used by the binary operators.
- Regression tests: `001_math/032_neg_abs_i64_min.ndc` and `900_bugs/bug0026_neg_abs_i64_min_overflow.ndc`.

Every other path produces the same results as before; only the `i64::MIN` boundary changes from a panic to the correct `9223372036854775808`.

🤖