### PR TITLE
fix(stdlib): error instead of panicking on reversed slice ranges 🔪

### DIFF
--- a/manual/src/snippets/slices.md
+++ b/manual/src/snippets/slices.md
@@ -12,3 +12,7 @@ assert_eq([30, 40, 50, 60], my_list[3..=6]);
 // Negative indices: Counting from the end of the list
 assert_eq([80, 90], my_list[-3..-1]);
 ```
+
+A range whose start lands after its end (for example `my_list[6..3]`) is out of
+bounds and raises an error rather than returning a reversed or empty slice. This
+holds for lists, strings, tuples and deques alike.

--- a/ndc_stdlib/src/index.rs
+++ b/ndc_stdlib/src/index.rs
@@ -212,6 +212,14 @@ fn to_forward_index(i: i64, size: usize, for_slice: bool) -> Result<usize, VmErr
     }
 }
 
+/// Resolves a (possibly negative) slice endpoint to a forward position without
+/// clamping it into `0..=size`. Used purely to detect reversed ranges: clamping
+/// would collapse out-of-range endpoints to the boundary (e.g. `6` and `5` both
+/// becoming `size` on a 5-element string), masking a reversal like `6..=5`.
+fn unclamped_slice_index(i: i64, size: usize) -> i64 {
+    if i < 0 { size as i64 + i } else { i }
+}
+
 enum VmOffset {
     Element(usize),
     Range(usize, usize),
@@ -223,16 +231,19 @@ fn extract_vm_offset(index_value: &Value, size: usize) -> Result<VmOffset, VmErr
     {
         let iter_ref = iter.borrow();
         if let Some((start, end, inclusive)) = iter_ref.range_bounds() {
-            let from_idx = to_forward_index(start, size, true)?;
-            let to_idx = to_forward_index(end, size, true)?;
-            // Reject reversed ranges before widening an inclusive end, otherwise
-            // an off-by-one inclusive range like `1..=0` would survive the `+1`
-            // and silently produce an empty slice instead of an error.
-            if to_idx < from_idx {
+            // Detect reversal from the unclamped endpoints, so an out-of-range
+            // reversed range can't collapse to equality once clamped (e.g.
+            // `6..=5` on a 5-element string would otherwise clamp both ends to
+            // 5 and silently yield an empty slice instead of an error).
+            let from_unclamped = unclamped_slice_index(start, size);
+            let end_unclamped = unclamped_slice_index(end, size);
+            if end_unclamped < from_unclamped {
                 return Err(VmError::native(format!(
-                    "{from_idx}..{to_idx} out of bounds"
+                    "{from_unclamped}..{end_unclamped} out of bounds"
                 )));
             }
+            let from_idx = to_forward_index(start, size, true)?;
+            let to_idx = to_forward_index(end, size, true)?;
             let to_idx = if inclusive {
                 (to_idx + 1).min(size)
             } else {

--- a/ndc_stdlib/src/index.rs
+++ b/ndc_stdlib/src/index.rs
@@ -225,16 +225,19 @@ fn extract_vm_offset(index_value: &Value, size: usize) -> Result<VmOffset, VmErr
         if let Some((start, end, inclusive)) = iter_ref.range_bounds() {
             let from_idx = to_forward_index(start, size, true)?;
             let to_idx = to_forward_index(end, size, true)?;
-            let to_idx = if inclusive {
-                (to_idx + 1).min(size)
-            } else {
-                to_idx
-            };
+            // Reject reversed ranges before widening an inclusive end, otherwise
+            // an off-by-one inclusive range like `1..=0` would survive the `+1`
+            // and silently produce an empty slice instead of an error.
             if to_idx < from_idx {
                 return Err(VmError::native(format!(
                     "{from_idx}..{to_idx} out of bounds"
                 )));
             }
+            let to_idx = if inclusive {
+                (to_idx + 1).min(size)
+            } else {
+                to_idx
+            };
             return Ok(VmOffset::Range(from_idx, to_idx));
         }
         if let Some(start) = iter_ref.unbounded_range_start() {

--- a/ndc_stdlib/src/index.rs
+++ b/ndc_stdlib/src/index.rs
@@ -230,6 +230,11 @@ fn extract_vm_offset(index_value: &Value, size: usize) -> Result<VmOffset, VmErr
             } else {
                 to_idx
             };
+            if to_idx < from_idx {
+                return Err(VmError::native(format!(
+                    "{from_idx}..{to_idx} out of bounds"
+                )));
+            }
             return Ok(VmOffset::Range(from_idx, to_idx));
         }
         if let Some(start) = iter_ref.unbounded_range_start() {

--- a/tests/functional/programs/009_slicing/008_reversed_string_slice.ndc
+++ b/tests/functional/programs/009_slicing/008_reversed_string_slice.ndc
@@ -1,0 +1,4 @@
+// expect-error: 3..1 out of bounds
+// A reversed range on a string used to panic with "attempt to subtract with
+// overflow"; it must now error gracefully like list/tuple slices do.
+"hello"[3..1]

--- a/tests/functional/programs/009_slicing/009_reversed_deque_slice.ndc
+++ b/tests/functional/programs/009_slicing/009_reversed_deque_slice.ndc
@@ -1,0 +1,8 @@
+// expect-error: 1..0 out of bounds
+// A reversed range on a deque used to panic with "attempt to subtract with
+// overflow"; it must now error gracefully.
+let d = Deque();
+d.push_back(1);
+d.push_back(2);
+d.push_back(3);
+d[1..0]

--- a/tests/functional/programs/009_slicing/010_reversed_slice_assignment.ndc
+++ b/tests/functional/programs/009_slicing/010_reversed_slice_assignment.ndc
@@ -1,0 +1,5 @@
+// expect-error: 3..1 out of bounds
+// Assigning into a reversed slice used to panic with "attempt to subtract with
+// overflow"; it must now error gracefully.
+let x = [1, 2, 3, 4];
+x[3..1] = [9]

--- a/tests/functional/programs/009_slicing/011_reversed_inclusive_slice.ndc
+++ b/tests/functional/programs/009_slicing/011_reversed_inclusive_slice.ndc
@@ -1,0 +1,4 @@
+// expect-error: 2..1 out of bounds
+// An inclusive range whose start is after its end (off-by-one, so the `+1`
+// widening would otherwise mask it) must error, not return an empty slice.
+"hello"[2..=1]

--- a/tests/functional/programs/009_slicing/012_reversed_slice_beyond_length.ndc
+++ b/tests/functional/programs/009_slicing/012_reversed_slice_beyond_length.ndc
@@ -1,0 +1,5 @@
+// expect-error: 6..5 out of bounds
+// A reversed range whose endpoints are both at or beyond the length used to
+// clamp to equal indices and return an empty slice. Reversal is now detected
+// from the unclamped endpoints, so it errors.
+"hello"[6..=5]


### PR DESCRIPTION
## Context

The fuzzer didn't catch this, but a slice whose start index lands after its end (`"hello"[3..1]`) crashes the interpreter with `attempt to subtract with overflow` instead of returning an error. Found while hunting for panics in the lexer/parser/analyser/compiler/vm pipeline.

Lists and tuples already handle reversed ranges gracefully because they slice via `slice.get(from..to)`, which returns `None`. Strings, deques, and slice assignment instead compute `take(to - from)`, which underflows when `from > to`.

## Changes

- `ndc_stdlib/src/index.rs`: `extract_vm_offset` now rejects a range whose forward start exceeds its end, returning a `{from}..{to} out of bounds` error. Centralizing the check covers every container type (string, deque, slice assignment) and keeps the existing list/tuple error message unchanged.
- Three regression tests under `tests/functional/programs/009_slicing/` cover the string, deque, and slice-assignment paths that used to panic.
- `manual/src/snippets/slices.md`: documents that a start-after-end range is out of bounds.

The behavior now matches what lists and tuples already did, so the existing `006_negative_range.ndc` test still passes against the same message.

🤖