### PR TITLE
fix(bin): run interpreter on a large-stack thread to avoid deep-nesting overflow 🌀

### DIFF
--- a/ndc_bin/src/main.rs
+++ b/ndc_bin/src/main.rs
@@ -150,7 +150,33 @@ impl TryFrom<Command> for Action {
     }
 }
 
+/// Stack size for the worker thread that runs the interpreter.
+///
+/// The parser, analyser, compiler, and VM all walk the AST recursively, one
+/// native frame per nesting level. The default main-thread stack is small
+/// enough that deeply (but legitimately) nested programs overflow it and abort
+/// the process. A generous stack keeps that from happening for any realistic
+/// source. The reservation is virtual address space; only the pages actually
+/// touched cost memory.
+const INTERPRETER_STACK_SIZE: usize = 512 * 1024 * 1024;
+
 fn main() -> anyhow::Result<()> {
+    // Run everything on a worker thread with a large explicit stack. The
+    // interpreter uses `Rc` and is not `Send`, but it is created, used, and
+    // dropped entirely inside this closure, so nothing crosses the boundary.
+    let worker = std::thread::Builder::new()
+        .name("ndc-interpreter".into())
+        .stack_size(INTERPRETER_STACK_SIZE)
+        .spawn(run)
+        .expect("failed to spawn interpreter thread");
+
+    match worker.join() {
+        Ok(result) => result,
+        Err(panic) => std::panic::resume_unwind(panic),
+    }
+}
+
+fn run() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     let action: Action = cli.command.unwrap_or_default().try_into()?;

--- a/ndc_bin/tests/deep_nesting.rs
+++ b/ndc_bin/tests/deep_nesting.rs
@@ -1,0 +1,46 @@
+//! Regression test: deeply nested input must not crash the interpreter.
+//!
+//! Each nesting level costs a native stack frame in the parser and in every
+//! later phase that walks the AST. On the default main-thread stack this used
+//! to overflow and abort the process (SIGABRT) at a few hundred levels. `ndc`
+//! now runs the interpreter on a worker thread with a large explicit stack, so
+//! input far deeper than that evaluates normally. See
+//! <https://github.com/timfennis/andy-cpp/issues/175>.
+
+// This integration test links `ndc_bin`'s dependencies but drives the built
+// binary instead of calling them, so silence `unused-crate-dependencies`.
+#![allow(unused_crate_dependencies)]
+
+use std::fs;
+use std::process::Command;
+
+#[test]
+fn deeply_nested_input_does_not_overflow_the_stack() {
+    // Deep enough to overflow the default main-thread stack (which gave up
+    // around a few hundred levels), shallow enough to fit the worker thread's
+    // large stack with room to spare.
+    let depth = 2000;
+    let source = format!("print({}1{})", "(".repeat(depth), ")".repeat(depth));
+
+    let path = std::env::temp_dir().join(format!("ndc_deep_nesting_{}.ndc", std::process::id()));
+    fs::write(&path, &source).expect("write temp script");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ndc"))
+        .arg(&path)
+        .output()
+        .expect("run ndc");
+
+    let _ = fs::remove_file(&path);
+
+    assert!(
+        output.status.success(),
+        "ndc crashed on {depth}-deep nesting (status {:?}); a stack overflow would show up here.\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "1",
+        "the nested expression should evaluate to 1",
+    );
+}


### PR DESCRIPTION
## Context

While hunting for crashes in the pipeline, I found that deeply nested input aborts the whole process with `fatal runtime error: stack overflow` (SIGABRT; a Rust panic handler can't catch it). It reproduces from short scripts: nested `(((…)))`, `[[[…]]]`, `{{{…}}}`, nested calls and tuples, and long `---…`, `not not …`, `2^2^…` chains. Each nesting level costs one native stack frame in the parser and in every later phase that walks the AST. Tracked in #175.

## Approach

The parser, analyser, compiler, and VM all recurse over the AST, so the overflow isn't confined to one crate. Rather than thread a depth cap through the recursive descent (which clutters the parser), `ndc` now runs the interpreter on a worker thread with a large explicit stack. Input far deeper than any realistic source evaluates instead of crashing.

## Changes

- **`ndc_bin`**: spawn a worker thread with a 512 MiB stack and run the whole interpreter on it. The interpreter uses `Rc` and isn't `Send`, but the closure creates, uses, and drops it on the worker thread, so nothing crosses the boundary. The reservation is virtual address space; only touched pages cost memory.
- **`ndc_bin/tests/deep_nesting.rs`**: drive the built binary on 2000-deep nesting and assert it evaluates rather than aborting. That depth overflows the default main-thread stack but fits the worker stack with room to spare.

## Notes for reviewers

- This raises the ceiling rather than imposing a hard limit: adversarial input nested deep enough (tens of thousands of levels) can still exhaust even the large stack. If we want a hard bound later, a depth cap is the follow-up; I left it out here to keep the parser clean.
- The LSP and the `cargo test` functional harness also walk the AST off the main thread on default-sized stacks, so they remain susceptible to very deep input. They can get the same large-stack treatment if it ever matters.

🤖
