### PR TITLE
refactor(compiler): lay out temporaries after lowering 🧩

### DIFF
--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -7,7 +7,7 @@ use ndc_core::{StaticType, TypeSignature};
 use ndc_lexer::Span;
 use ndc_parser::{
     AugmentedAssignmentPlan, Binding, Candidate, Expression, ExpressionLocation, ForBody,
-    ForIteration, FunctionParameter, Lvalue, NodeId, SourceLocalCounts,
+    ForIteration, FunctionParameter, Lvalue, NodeId,
 };
 
 /// Side table holding semantic information keyed by AST node identity.
@@ -19,9 +19,6 @@ pub struct AnalysisResult {
     /// Inferred return types for functions without explicit annotations.
     /// Keyed by the FunctionDeclaration's `NodeId`.
     pub inferred_return_types: HashMap<NodeId, StaticType>,
-    /// Analyser-assigned source-local high-water marks consumed by the compiler
-    /// before it allocates hidden temporaries.
-    pub source_local_counts: SourceLocalCounts,
     /// Errors accumulated during analysis. Non-empty when the analyser
     /// encountered problems but was able to continue with fallback types.
     pub errors: Vec<AnalysisError>,
@@ -89,13 +86,6 @@ impl Analyser {
     ) -> Result<StaticType, AnalysisError> {
         let typ = self.analyse_inner(expr_loc)?;
         self.result.expr_types.insert(expr_loc.id, typ.clone());
-        if self.scope_tree.current_function_is_top_level() {
-            self.result.source_local_counts.top_level = self
-                .result
-                .source_local_counts
-                .top_level
-                .max(self.scope_tree.current_function_local_count());
-        }
         Ok(typ)
     }
 
@@ -323,10 +313,6 @@ impl Analyser {
                 let implicit_return = self.analyse_or_any(body);
                 let explicit_return = self.return_type_stack.pop().unwrap();
                 *captures = self.scope_tree.current_scope_captures();
-                self.result
-                    .source_local_counts
-                    .functions
-                    .insert(*id, self.scope_tree.current_function_local_count());
                 self.scope_tree.destroy_scope();
 
                 // Combine explicit `return` types with the block's implicit return type.
@@ -1087,67 +1073,6 @@ mod tests {
             analyse_last_type("let values = [1]; values[0] = \"two\"; values"),
             StaticType::List(Box::new(StaticType::Any)),
         );
-    }
-
-    #[test]
-    fn source_local_counts_are_recorded_per_function_frame() {
-        let (_, result) = analyse_with_globals(
-            r#"
-                let top = 0;
-                { let scoped = 1; scoped };
-                fn outer(arg) {
-                    let local = arg;
-                    fn inner(inner_arg) {
-                        let nested = inner_arg;
-                        nested
-                    };
-                    local
-                };
-            "#,
-            vec![],
-        );
-
-        assert!(
-            result.errors.is_empty(),
-            "analysis errors: {:?}",
-            result.errors
-        );
-        assert_eq!(result.source_local_counts.top_level, 2);
-        let mut function_counts: Vec<_> = result
-            .source_local_counts
-            .functions
-            .values()
-            .copied()
-            .collect();
-        function_counts.sort_unstable();
-        assert_eq!(function_counts, [2, 3]);
-    }
-
-    #[test]
-    fn top_level_source_local_count_is_monotonic_across_batches() {
-        let mut analyser = Analyser::from_scope_tree(ScopeTree::from_global_scope(vec![]));
-
-        for (source, expected) in [
-            ("{ let first = 1; let second = 2; second };", 2),
-            ("let root = 0;", 2),
-            ("let next = 1; let last = 2;", 3),
-        ] {
-            let tokens = Lexer::new(source, SourceId::SYNTHETIC)
-                .collect::<Result<Vec<_>, _>>()
-                .expect("lex failed");
-            let mut expressions = Parser::from_tokens(tokens).parse().expect("parse failed");
-            for expression in &mut expressions {
-                analyser.analyse(expression).expect("analysis failed");
-            }
-
-            let result = analyser.take_result();
-            assert!(
-                result.errors.is_empty(),
-                "analysis errors: {:?}",
-                result.errors
-            );
-            assert_eq!(result.source_local_counts.top_level, expected);
-        }
     }
 
     #[test]

--- a/ndc_analyser/src/scope.rs
+++ b/ndc_analyser/src/scope.rs
@@ -130,9 +130,6 @@ pub(crate) struct Scope {
     creates_environment: bool, // Only true for function scopes and for-loop iterations
     base_offset: usize,
     function_scope_idx: usize,
-    /// Source-local high-water mark for this function frame. Only meaningful
-    /// on the function scope itself; child scopes update their owning frame.
-    local_count: usize,
     identifiers: Vec<ScopeBinding>,
     upvalues: Vec<(String, CaptureSource)>,
 }
@@ -148,7 +145,6 @@ impl Scope {
             creates_environment: true,
             base_offset: 0,
             function_scope_idx,
-            local_count: 0,
             identifiers: Vec::default(),
             upvalues: Vec::default(),
         }
@@ -164,7 +160,6 @@ impl Scope {
             creates_environment: false,
             base_offset,
             function_scope_idx,
-            local_count: 0,
             identifiers: Vec::default(),
             upvalues: Vec::default(),
         }
@@ -482,18 +477,6 @@ impl ScopeTree {
             .iter()
             .map(|(_, source)| source.clone())
             .collect()
-    }
-
-    /// Highest source-local slot used by the current function frame, plus one.
-    /// Child scopes update this value as bindings are allocated, so destroyed
-    /// block and iteration scopes remain represented in the high-water mark.
-    pub(crate) fn current_function_local_count(&self) -> usize {
-        let function_scope_idx = self.scopes[self.current_scope_idx].function_scope_idx;
-        self.scopes[function_scope_idx].local_count
-    }
-
-    pub(crate) fn current_function_is_top_level(&self) -> bool {
-        self.scopes[self.current_scope_idx].function_scope_idx == 0
     }
 
     // When the Analyser encounters an identifier as the rhs of an expression during resolution it
@@ -874,11 +857,9 @@ impl ScopeTree {
         ident: String,
         binding: TypeBinding,
     ) -> ResolvedVar {
-        let function_scope_idx = self.scopes[self.current_scope_idx].function_scope_idx;
-        let slot = self.scopes[self.current_scope_idx].allocate(ident, binding);
-        self.scopes[function_scope_idx].local_count =
-            self.scopes[function_scope_idx].local_count.max(slot + 1);
-        ResolvedVar::Local { slot }
+        ResolvedVar::Local {
+            slot: self.scopes[self.current_scope_idx].allocate(ident, binding),
+        }
     }
 
     /// Check whether the current scope already has a `fn` declaration with

--- a/ndc_interpreter/src/lib.rs
+++ b/ndc_interpreter/src/lib.rs
@@ -1,7 +1,7 @@
 use ndc_analyser::{Analyser, ScopeTree};
 use ndc_core::FunctionRegistry;
 use ndc_lexer::{Lexer, SourceDb, SourceId, TokenLocation};
-use ndc_parser::{ExpressionLocation, SourceLocalCounts};
+use ndc_parser::ExpressionLocation;
 use ndc_vm::compiler::Compiler;
 use ndc_vm::value::CompiledFunction;
 use ndc_vm::{OutputSink, Vm};
@@ -121,11 +121,8 @@ impl Interpreter {
 
     pub fn compile_str(&mut self, input: &str) -> Result<CompiledFunction, InterpreterError> {
         let source_id = self.source_db.add("<input>", input);
-        let (expressions, analysis, _) = self.parse_and_analyse(input, source_id)?;
-        Ok(Compiler::compile(
-            expressions.into_iter(),
-            analysis.source_local_counts,
-        )?)
+        let (expressions, _, _) = self.parse_and_analyse(input, source_id)?;
+        Ok(Compiler::compile(expressions.into_iter())?)
     }
 
     /// Like [`Self::compile_str`] but skips the peephole optimizer.
@@ -135,11 +132,8 @@ impl Interpreter {
         input: &str,
     ) -> Result<CompiledFunction, InterpreterError> {
         let source_id = self.source_db.add("<input>", input);
-        let (expressions, analysis, _) = self.parse_and_analyse(input, source_id)?;
-        Ok(Compiler::compile_unoptimized(
-            expressions.into_iter(),
-            analysis.source_local_counts,
-        )?)
+        let (expressions, _, _) = self.parse_and_analyse(input, source_id)?;
+        Ok(Compiler::compile_unoptimized(expressions.into_iter())?)
     }
 
     pub fn disassemble_str(&mut self, input: &str) -> Result<String, InterpreterError> {
@@ -177,9 +171,8 @@ impl Interpreter {
         // fails — otherwise the analyser would remember declarations from a line
         // that never actually ran.
         let analyser_checkpoint = self.analyser.checkpoint();
-        let (expressions, analysis, mut timings) = self.parse_and_analyse(input, source_id)?;
-        let vm_result =
-            self.interpret_vm(input, expressions.into_iter(), analysis.source_local_counts);
+        let (expressions, _, mut timings) = self.parse_and_analyse(input, source_id)?;
+        let vm_result = self.interpret_vm(input, expressions.into_iter());
         if vm_result.is_err() {
             self.analyser.restore(analyser_checkpoint);
         }
@@ -235,7 +228,6 @@ impl Interpreter {
         #[cfg(feature = "trace")] input: &str,
         #[cfg(not(feature = "trace"))] _input: &str,
         expressions: impl Iterator<Item = ExpressionLocation>,
-        source_local_counts: SourceLocalCounts,
     ) -> Result<(Value, ExecutionTimings), InterpreterError> {
         use ndc_vm::{Function as VmFunction, Object as VmObject, Value as VmValue};
 
@@ -258,7 +250,7 @@ impl Interpreter {
                     OutputSink::Stdout
                 };
                 let (code, checkpoint) = measure(&mut timings, Phase::Compiling, || {
-                    Compiler::compile_resumable(expressions, source_local_counts)
+                    Compiler::compile_resumable(expressions)
                 })?;
                 let mut vm = Vm::new(code, globals).with_output(output);
                 #[cfg(feature = "trace")]
@@ -281,7 +273,7 @@ impl Interpreter {
                 // find their locals on the stack.
                 let old_checkpoint = checkpoint.clone();
                 let (code, new_checkpoint) = measure(&mut timings, Phase::Compiling, || {
-                    checkpoint.resume(expressions, source_local_counts)
+                    checkpoint.resume(expressions)
                 })?;
                 vm.resume_from_halt(code, globals, resume_ip, prev_num_locals);
                 #[cfg(feature = "trace")]

--- a/ndc_parser/src/expression.rs
+++ b/ndc_parser/src/expression.rs
@@ -4,7 +4,6 @@ use ndc_core::{StaticType, TypeSignature};
 use ndc_lexer::Span;
 use num::BigInt;
 use num::complex::Complex64;
-use std::collections::HashMap;
 use std::sync::atomic::{AtomicU32, Ordering};
 
 /// Unique identity for an AST node. Used as a key in side tables (e.g. the
@@ -18,23 +17,6 @@ impl NodeId {
     pub fn next() -> Self {
         Self(NEXT_NODE_ID.fetch_add(1, Ordering::Relaxed))
     }
-}
-
-/// Analyser-assigned source-local high-water marks for each compilation frame.
-///
-/// The top-level count remains monotonic across REPL analysis batches. Nested
-/// functions use independent slot namespaces and are keyed by their declaration
-/// node so the compiler can reserve their source slots before hidden temporaries.
-///
-/// This is transitional metadata while the compiler consumes the resolved AST
-/// directly. When HIR is introduced, lowering should represent source locals
-/// and generated temporaries as logical local IDs. A frame-layout pass can then
-/// assign slots and store `num_locals` directly on each HIR module or function,
-/// replacing this top-level count and `NodeId` side table.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct SourceLocalCounts {
-    pub top_level: usize,
-    pub functions: HashMap<NodeId, usize>,
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/ndc_parser/src/lib.rs
+++ b/ndc_parser/src/lib.rs
@@ -4,7 +4,7 @@ mod parser;
 
 pub use expression::{
     AugmentedAssignmentPlan, Binding, Candidate, CaptureSource, Expression, ExpressionLocation,
-    ForBody, ForIteration, FunctionParameter, Lvalue, NodeId, ResolvedVar, SourceLocalCounts,
+    ForBody, ForIteration, FunctionParameter, Lvalue, NodeId, ResolvedVar,
 };
 pub use operator::{BinaryOperator, LogicalOperator, UnaryOperator};
 pub use parser::Error;

--- a/ndc_vm/src/chunk.rs
+++ b/ndc_vm/src/chunk.rs
@@ -337,6 +337,27 @@ impl OptimizerIr {
         }
     }
 
+    /// Assigns a concrete frame slot to a compiler-generated local operation.
+    pub(crate) fn set_local_slot(&mut self, label: LabelId, slot: usize) {
+        let idx = self
+            .code
+            .iter()
+            .position(|(l, _, _)| *l == label)
+            .expect("invalid label");
+
+        match self.code.get_mut(idx) {
+            Some((
+                _label,
+                OpCode::GetLocal(n)
+                | OpCode::SetLocal(n)
+                | OpCode::ListPush(n)
+                | OpCode::MapInsert(n),
+                _span,
+            )) => *n = slot,
+            _ => panic!("expected a compiler-generated local instruction at index {idx}"),
+        }
+    }
+
     pub(crate) fn write(&mut self, op: OpCode, span: Span) -> LabelId {
         let label = self.next_label();
         self.code.push((label, op, span));

--- a/ndc_vm/src/chunk.rs
+++ b/ndc_vm/src/chunk.rs
@@ -338,14 +338,8 @@ impl OptimizerIr {
     }
 
     /// Assigns a concrete frame slot to a compiler-generated local operation.
-    pub(crate) fn set_local_slot(&mut self, label: LabelId, slot: usize) {
-        let idx = self
-            .code
-            .iter()
-            .position(|(l, _, _)| *l == label)
-            .expect("invalid label");
-
-        match self.code.get_mut(idx) {
+    pub(crate) fn set_local_slot(&mut self, instruction_idx: usize, slot: usize) {
+        match self.code.get_mut(instruction_idx) {
             Some((
                 _label,
                 OpCode::GetLocal(n)
@@ -354,7 +348,9 @@ impl OptimizerIr {
                 | OpCode::MapInsert(n),
                 _span,
             )) => *n = slot,
-            _ => panic!("expected a compiler-generated local instruction at index {idx}"),
+            _ => {
+                panic!("expected a compiler-generated local instruction at index {instruction_idx}")
+            }
         }
     }
 

--- a/ndc_vm/src/compiler.rs
+++ b/ndc_vm/src/compiler.rs
@@ -5,30 +5,31 @@ use ndc_core::{StaticType, TypeSignature};
 use ndc_lexer::Span;
 use ndc_parser::{
     AugmentedAssignmentPlan, Binding, Candidate, CaptureSource, Expression, ExpressionLocation,
-    ForBody, ForIteration, FunctionParameter, LogicalOperator, Lvalue, NodeId, ResolvedVar,
-    SourceLocalCounts,
+    ForBody, ForIteration, FunctionParameter, LogicalOperator, Lvalue, ResolvedVar,
 };
 use std::rc::Rc;
 
 #[derive(Clone)]
 pub struct Compiler {
     ir: OptimizerIr,
-    num_locals: usize,
+    source_locals: usize,
+    temp_count: usize,
+    temp_uses: Vec<TempUse>,
     loop_stack: Vec<LoopContext>,
     allow_return: bool,
     optimize: bool,
-    source_local_counts: Rc<SourceLocalCounts>,
 }
 
 impl Default for Compiler {
     fn default() -> Self {
         Self {
             ir: OptimizerIr::default(),
-            num_locals: 0,
+            source_locals: 0,
+            temp_count: 0,
+            temp_uses: Vec::new(),
             loop_stack: Vec::new(),
             allow_return: false,
             optimize: true,
-            source_local_counts: Rc::new(SourceLocalCounts::default()),
         }
     }
 }
@@ -36,9 +37,8 @@ impl Default for Compiler {
 impl Compiler {
     pub fn compile(
         expressions: impl Iterator<Item = ExpressionLocation>,
-        source_local_counts: SourceLocalCounts,
     ) -> Result<CompiledFunction, CompileError> {
-        let mut compiler = Self::with_source_local_counts(true, source_local_counts);
+        let mut compiler = Self::default();
         compiler.compile_batch(expressions.collect())?;
         Ok(compiler.finish()?.0)
     }
@@ -48,9 +48,11 @@ impl Compiler {
     /// debugging tools (e.g. a future `--no-optimize` disassembler flag).
     pub fn compile_unoptimized(
         expressions: impl Iterator<Item = ExpressionLocation>,
-        source_local_counts: SourceLocalCounts,
     ) -> Result<CompiledFunction, CompileError> {
-        let mut compiler = Self::with_source_local_counts(false, source_local_counts);
+        let mut compiler = Self {
+            optimize: false,
+            ..Default::default()
+        };
         compiler.compile_batch(expressions.collect())?;
         Ok(compiler.finish()?.0)
     }
@@ -65,9 +67,11 @@ impl Compiler {
     /// the emitted chunk, and shifting instructions invalidates that.
     pub fn compile_resumable(
         expressions: impl Iterator<Item = ExpressionLocation>,
-        source_local_counts: SourceLocalCounts,
     ) -> Result<(CompiledFunction, Self), CompileError> {
-        let mut compiler = Self::with_source_local_counts(false, source_local_counts);
+        let mut compiler = Self {
+            optimize: false,
+            ..Default::default()
+        };
         compiler.compile_batch(expressions.collect())?;
         compiler.finish()
     }
@@ -82,22 +86,10 @@ impl Compiler {
     pub fn resume(
         self,
         new_expressions: impl Iterator<Item = ExpressionLocation>,
-        source_local_counts: SourceLocalCounts,
     ) -> Result<(CompiledFunction, Self), CompileError> {
         let mut compiler = self; // checkpoint has no trailing Halt
-        compiler.num_locals = compiler.num_locals.max(source_local_counts.top_level);
-        compiler.source_local_counts = Rc::new(source_local_counts);
         compiler.compile_batch(new_expressions.collect())?;
         compiler.finish()
-    }
-
-    fn with_source_local_counts(optimize: bool, source_local_counts: SourceLocalCounts) -> Self {
-        Self {
-            num_locals: source_local_counts.top_level,
-            optimize,
-            source_local_counts: Rc::new(source_local_counts),
-            ..Default::default()
-        }
     }
 
     fn compile_batch(&mut self, expressions: Vec<ExpressionLocation>) -> Result<(), CompileError> {
@@ -107,10 +99,22 @@ impl Compiler {
         Ok(())
     }
 
-    fn allocate_temp(&mut self) -> usize {
-        let slot = self.num_locals;
-        self.num_locals += 1;
-        slot
+    fn allocate_temp(&mut self) -> TempSlot {
+        let temp = TempSlot(self.temp_count);
+        self.temp_count += 1;
+        temp
+    }
+
+    fn write_temp(&mut self, temp: TempSlot, span: Span, opcode: impl FnOnce(usize) -> OpCode) {
+        let label = self.ir.write(opcode(0), span);
+        self.temp_uses.push(TempUse { label, temp });
+    }
+
+    fn layout_temporaries(&mut self) {
+        for temp_use in &self.temp_uses {
+            self.ir
+                .set_local_slot(temp_use.label, self.source_locals + temp_use.temp.0);
+        }
     }
 
     /// The instruction index where the trailing `Halt` was written.
@@ -121,17 +125,21 @@ impl Compiler {
 
     /// Number of top-level local slots used so far.
     pub fn num_locals(&self) -> usize {
-        self.num_locals
+        self.source_locals + self.temp_count
     }
 
     /// Internal: clone a checkpoint (pre-Halt), write Halt, return both.
     fn finish(mut self) -> Result<(CompiledFunction, Self), CompileError> {
+        // Keep resumable IR symbolic so later batches can grow the source-local
+        // range and lay out every compiler temporary against the new boundary.
         let checkpoint = self.clone();
+        self.layout_temporaries();
         self.ir.write(OpCode::Halt, Span::synthetic());
         if self.optimize {
             self.ir.peephole();
         }
 
+        let num_locals = self.num_locals();
         let function = CompiledFunction {
             name: None,
             static_type: StaticType::Function {
@@ -139,7 +147,7 @@ impl Compiler {
                 return_type: Box::new(StaticType::Any),
             },
             body: self.ir.into_chunk(),
-            num_locals: self.num_locals,
+            num_locals,
         };
         Ok((function, checkpoint))
     }
@@ -149,9 +157,7 @@ impl Compiler {
         expression_location: ExpressionLocation,
     ) -> Result<(), CompileError> {
         let ExpressionLocation {
-            expression,
-            span,
-            id,
+            expression, span, ..
         } = expression_location;
         match expression {
             Expression::BoolLiteral(b) => {
@@ -292,7 +298,6 @@ impl Compiler {
             } => {
                 let type_signature = FunctionParameter::from_params(&parameters);
                 self.compile_function_decl(
-                    id,
                     name,
                     resolved_name,
                     *body,
@@ -445,12 +450,12 @@ impl Compiler {
                 // 5. Pop the return value
 
                 let tmp_value = self.allocate_temp();
-                self.ir.write(OpCode::SetLocal(tmp_value), span);
+                self.write_temp(tmp_value, span, OpCode::SetLocal);
 
                 self.compile_binding(resolved_set.expect("[]= must be resolved"), span)?;
                 self.compile_expr(*value)?;
                 self.compile_expr(*index)?;
-                self.ir.write(OpCode::GetLocal(tmp_value), span);
+                self.write_temp(tmp_value, span, OpCode::GetLocal);
                 self.ir.write(OpCode::Call(3), span);
                 self.ir.write(OpCode::Pop, Span::synthetic());
             }
@@ -473,7 +478,7 @@ impl Compiler {
                     _ => unreachable!("declaration lvalue must be a local"),
                 };
                 self.ir.write(OpCode::SetLocal(slot), span);
-                self.num_locals = self.num_locals.max(slot + 1);
+                self.source_locals = self.source_locals.max(slot + 1);
             }
             Lvalue::Index { .. } => unreachable!("cannot declare into index"),
             Lvalue::Sequence(seq) => {
@@ -655,7 +660,6 @@ impl Compiler {
     #[allow(clippy::too_many_arguments)]
     fn compile_function_decl(
         &mut self,
-        node_id: NodeId,
         name: Option<String>,
         resolved_name: Option<ResolvedVar>,
         body: ExpressionLocation,
@@ -679,31 +683,26 @@ impl Compiler {
             },
             return_type: Box::new(return_type.clone()),
         };
-        let function_source_locals = self
-            .source_local_counts
-            .functions
-            .get(&node_id)
-            .copied()
-            .ok_or_else(|| CompileError::missing_source_local_count(node_id, span))?;
         let mut fn_compiler = Self {
-            num_locals: num_params.max(function_source_locals),
+            source_locals: num_params,
             allow_return: true,
             optimize: self.optimize,
-            source_local_counts: Rc::clone(&self.source_local_counts),
             ..Default::default()
         };
         fn_compiler.compile_expr(body)?;
         fn_compiler.ir.write(OpCode::Return, Span::synthetic());
+        fn_compiler.layout_temporaries();
 
         if fn_compiler.optimize {
             fn_compiler.ir.peephole();
         }
 
+        let num_locals = fn_compiler.num_locals();
         let compiled = CompiledFunction {
             name,
             static_type,
             body: fn_compiler.ir.into_chunk(),
-            num_locals: fn_compiler.num_locals,
+            num_locals,
         };
         let idx = self
             .ir
@@ -731,7 +730,7 @@ impl Compiler {
         match resolved_name {
             Some(ResolvedVar::Local { slot }) => {
                 self.ir.write(OpCode::SetLocal(slot), span);
-                self.num_locals = self.num_locals.max(slot + 1);
+                self.source_locals = self.source_locals.max(slot + 1);
             }
             Some(ResolvedVar::Upvalue { .. } | ResolvedVar::Global { .. }) => {
                 unreachable!("the analyser never assigns a declaration to a non-local binding")
@@ -762,13 +761,13 @@ impl Compiler {
             ForBody::List { expr } => {
                 let tmp_list = self.allocate_temp();
                 self.ir.write(OpCode::MakeList(0), span);
-                self.ir.write(OpCode::SetLocal(tmp_list), span);
+                self.write_temp(tmp_list, span, OpCode::SetLocal);
                 self.compile_for_iterations(iterations, span, &mut |this| {
                     this.compile_expr(expr.clone())?;
-                    this.ir.write(OpCode::ListPush(tmp_list), span);
+                    this.write_temp(tmp_list, span, OpCode::ListPush);
                     Ok(())
                 })?;
-                self.ir.write(OpCode::GetLocal(tmp_list), span);
+                self.write_temp(tmp_list, span, OpCode::GetLocal);
                 Ok(())
             }
             ForBody::Map {
@@ -788,7 +787,7 @@ impl Compiler {
                     },
                     span,
                 );
-                self.ir.write(OpCode::SetLocal(tmp_map), span);
+                self.write_temp(tmp_map, span, OpCode::SetLocal);
                 self.compile_for_iterations(iterations, span, &mut |this| {
                     this.compile_expr(key.clone())?;
                     if let Some(value) = value.clone() {
@@ -797,10 +796,10 @@ impl Compiler {
                         let idx = this.ir.add_constant(Value::unit());
                         this.ir.write(OpCode::Constant(idx), Span::synthetic());
                     }
-                    this.ir.write(OpCode::MapInsert(tmp_map), span);
+                    this.write_temp(tmp_map, span, OpCode::MapInsert);
                     Ok(())
                 })?;
-                self.ir.write(OpCode::GetLocal(tmp_map), span);
+                self.write_temp(tmp_map, span, OpCode::GetLocal);
                 Ok(())
             }
         }
@@ -900,6 +899,16 @@ struct LoopContext {
     break_instructions: Vec<LabelId>,
 }
 
+/// Logical compiler-local slot, assigned a concrete frame slot after lowering.
+#[derive(Clone, Copy)]
+struct TempSlot(usize);
+
+#[derive(Clone, Copy)]
+struct TempUse {
+    label: LabelId,
+    temp: TempSlot,
+}
+
 /// An assignment location whose side-effecting components have already been
 /// evaluated and cached. This lets augmented assignment use one lowering for
 /// every target without evaluating an index expression more than once.
@@ -909,8 +918,8 @@ enum PreparedAssignmentTarget {
         span: Span,
     },
     Index {
-        cached_container: usize,
-        cached_index: usize,
+        cached_container: TempSlot,
+        cached_index: TempSlot,
         container_span: Span,
         index_span: Span,
         getter: Binding,
@@ -937,13 +946,9 @@ impl PreparedAssignmentTarget {
                 let cached_index = compiler.allocate_temp();
 
                 compiler.compile_expr(*value)?;
-                compiler
-                    .ir
-                    .write(OpCode::SetLocal(cached_container), container_span);
+                compiler.write_temp(cached_container, container_span, OpCode::SetLocal);
                 compiler.compile_expr(*index)?;
-                compiler
-                    .ir
-                    .write(OpCode::SetLocal(cached_index), index_span);
+                compiler.write_temp(cached_index, index_span, OpCode::SetLocal);
 
                 Ok(Self::Index {
                     cached_container,
@@ -970,12 +975,8 @@ impl PreparedAssignmentTarget {
                 ..
             } => {
                 compiler.compile_binding(getter.clone(), *index_span)?;
-                compiler
-                    .ir
-                    .write(OpCode::GetLocal(*cached_container), *container_span);
-                compiler
-                    .ir
-                    .write(OpCode::GetLocal(*cached_index), *index_span);
+                compiler.write_temp(*cached_container, *container_span, OpCode::GetLocal);
+                compiler.write_temp(*cached_index, *index_span, OpCode::GetLocal);
                 compiler
                     .ir
                     .write(OpCode::Call(2), container_span.merge(*index_span));
@@ -998,19 +999,11 @@ impl PreparedAssignmentTarget {
                 let cached_value = compiler.allocate_temp();
                 let target_span = container_span.merge(*index_span);
 
-                compiler
-                    .ir
-                    .write(OpCode::SetLocal(cached_value), target_span);
+                compiler.write_temp(cached_value, target_span, OpCode::SetLocal);
                 compiler.compile_binding(setter.clone(), target_span)?;
-                compiler
-                    .ir
-                    .write(OpCode::GetLocal(*cached_container), *container_span);
-                compiler
-                    .ir
-                    .write(OpCode::GetLocal(*cached_index), *index_span);
-                compiler
-                    .ir
-                    .write(OpCode::GetLocal(cached_value), target_span);
+                compiler.write_temp(*cached_container, *container_span, OpCode::GetLocal);
+                compiler.write_temp(*cached_index, *index_span, OpCode::GetLocal);
+                compiler.write_temp(cached_value, target_span, OpCode::GetLocal);
                 compiler.ir.write(OpCode::Call(3), target_span);
                 compiler.ir.write(OpCode::Pop, target_span);
             }
@@ -1059,15 +1052,6 @@ pub struct CompileError {
 }
 
 impl CompileError {
-    fn missing_source_local_count(node_id: NodeId, span: Span) -> Self {
-        Self {
-            text: format!(
-                "missing source-local count for function node {node_id:?}; analysed AST and metadata must be compiled together"
-            ),
-            span,
-        }
-    }
-
     fn unresolved_binding(span: Span) -> Self {
         Self {
             text: "encountered unresolved binding during compilation, this is probably an internal error".to_string(),

--- a/ndc_vm/src/compiler.rs
+++ b/ndc_vm/src/compiler.rs
@@ -106,14 +106,20 @@ impl Compiler {
     }
 
     fn write_temp(&mut self, temp: TempSlot, span: Span, opcode: impl FnOnce(usize) -> OpCode) {
-        let label = self.ir.write(opcode(0), span);
-        self.temp_uses.push(TempUse { label, temp });
+        let instruction_idx = self.ir.len();
+        self.ir.write(opcode(0), span);
+        self.temp_uses.push(TempUse {
+            instruction_idx,
+            temp,
+        });
     }
 
     fn layout_temporaries(&mut self) {
         for temp_use in &self.temp_uses {
-            self.ir
-                .set_local_slot(temp_use.label, self.source_locals + temp_use.temp.0);
+            self.ir.set_local_slot(
+                temp_use.instruction_idx,
+                self.source_locals + temp_use.temp.0,
+            );
         }
     }
 
@@ -905,7 +911,7 @@ struct TempSlot(usize);
 
 #[derive(Clone, Copy)]
 struct TempUse {
-    label: LabelId,
+    instruction_idx: usize,
     temp: TempSlot,
 }
 

--- a/tests/compiler/tests/compiler.rs
+++ b/tests/compiler/tests/compiler.rs
@@ -14,7 +14,7 @@ fn compile(input: &str) -> Vec<OpCode> {
         .collect::<Result<Vec<_>, _>>()
         .expect("lex failed");
     let expressions = Parser::from_tokens(tokens).parse().expect("parse failed");
-    Compiler::compile_unoptimized(expressions.into_iter(), Default::default())
+    Compiler::compile_unoptimized(expressions.into_iter())
         .expect("compile failed")
         .opcodes()
         .to_vec()
@@ -432,25 +432,6 @@ fn test_augmented_assignment_temporaries_follow_source_locals() {
             && ops.iter().any(|op| matches!(op, SetLocal(3)))
             && ops.iter().any(|op| matches!(op, SetLocal(4))),
         "prepared-target temporaries must be allocated after both source locals: {ops:?}",
-    );
-}
-
-// Resolved function AST and its analyser metadata form one compilation unit.
-// Omitting the per-function frame size must fail instead of silently reserving
-// only parameter slots and allowing hidden temporaries to overlap body locals.
-#[test]
-fn test_missing_function_source_local_count_is_rejected() {
-    let mut interp = ndc_interpreter::Interpreter::capturing();
-    let (expressions, _) = interp
-        .analyse_str("fn f() { let local = 1; local }")
-        .expect("analysis failed");
-
-    let Err(error) = Compiler::compile(expressions.into_iter(), Default::default()) else {
-        panic!("compilation should reject missing source-local metadata");
-    };
-    assert!(
-        error.to_string().contains("missing source-local count"),
-        "unexpected compile error: {error}",
     );
 }
 

--- a/tests/compiler/tests/optimizer.rs
+++ b/tests/compiler/tests/optimizer.rs
@@ -13,14 +13,14 @@ fn parse(input: &str) -> Vec<ndc_parser::ExpressionLocation> {
 }
 
 fn unoptimized(input: &str) -> Vec<OpCode> {
-    Compiler::compile_unoptimized(parse(input).into_iter(), Default::default())
+    Compiler::compile_unoptimized(parse(input).into_iter())
         .expect("compile failed")
         .opcodes()
         .to_vec()
 }
 
 fn optimized(input: &str) -> Vec<OpCode> {
-    Compiler::compile(parse(input).into_iter(), Default::default())
+    Compiler::compile(parse(input).into_iter())
         .expect("compile failed")
         .opcodes()
         .to_vec()

--- a/tests/proptest/tests/panic.rs
+++ b/tests/proptest/tests/panic.rs
@@ -247,7 +247,7 @@ fn run_pipeline(tokens: Vec<TokenLocation>) {
         return;
     }
 
-    let compiled = match Compiler::compile(expressions.into_iter(), Default::default()) {
+    let compiled = match Compiler::compile(expressions.into_iter()) {
         Ok(c) => c,
         Err(_) => return,
     };


### PR DESCRIPTION
## Summary

- represent compiler-generated locals as logical temporary slots until a function frame is fully lowered
- patch only materialized compiler IR so resumable checkpoints can adapt when later REPL batches introduce source locals
- remove `SourceLocalCounts` and its parser, analyser, interpreter, and compiler API plumbing

## Testing

- `cargo fmt --all -- --check`
- `cargo test --workspace`
- `cargo build --no-default-features`

## AI disclosure

OpenAI Codex (GPT-5) was used to design and implement the late temporary-slot layout, remove the transitional metadata plumbing, run verification, and draft this PR description.