### PR TITLE
chore: augmented assignment review follow-ups 🧹

### DIFF
--- a/manual/src/features/augmented-assignment.md
+++ b/manual/src/features/augmented-assignment.md
@@ -11,6 +11,61 @@ my_number += 5;
 assert_eq(my_number, 8);
 ```
 
+## Indexed targets
+
+The target of an augmented assignment can also be an indexed location:
+
+```ndc
+let values = [1, 2, 3];
+values[0] += 10;
+assert_eq(values, [11, 2, 3]);
+```
+
+This works even when reading the location produces a new value rather than a
+reference, such as a character of a string or a slice of a list. The updated
+value is always stored back into the container:
+
+```ndc
+let text = "ab";
+text[0] ++= "x";
+assert_eq(text, "axb");
+
+let items = [1, 2];
+items[0..1] ++= [3];
+assert_eq(items, [1, 3, 2]);
+```
+
+The target, index, and right-hand side are each evaluated exactly once, in
+source order. The augmented assignment expression itself evaluates to `()`.
+
+## Type checking
+
+An augmented assignment with an in-place operator such as `++=` never changes
+the type of its target. If the right-hand side would force a type change the
+program is rejected:
+
+```ndc
+let values = [1];
+values ++= ["two"]; // error: mismatched types: found List<String> but expected List<Int>
+```
+
+Annotate the target with `Any` to opt into heterogeneous contents:
+
+```ndc
+let mixed: List<Any> = [1];
+mixed ++= ["two"];
+assert_eq(mixed, [1, "two"]);
+```
+
+Operators without an in-place implementation behave like `target = target op value`
+and may widen the inferred type of the target, just like a regular assignment:
+
+```ndc
+let numbers = [1];
+numbers[0] += 0.5; // fine: the element type widens from Int to Number
+assert_eq(numbers, [1.5]);
+```
+
 ## Optimization
 
 You might expect `list ++= [1,2,3]` to desugar to `list = list ++ [1,2,3]`, but that would waste work. Andy C++ handles some augmented assignments directly. In this case, it appends `[1,2,3]` without creating an intermediate list.

--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -244,11 +244,11 @@ impl Analyser {
                         *plan = AugmentedAssignmentPlan::Unresolved;
                         None
                     }
-                    _ if has_op_binding => {
+                    Binding::None if has_op_binding => {
                         *plan = AugmentedAssignmentPlan::Resolved(op_binding);
                         Some(op_return)
                     }
-                    _ => {
+                    Binding::None => {
                         self.emit(AnalysisError::function_not_found(
                             operation, &arg_types, *span,
                         ));
@@ -630,8 +630,7 @@ impl Analyser {
                         .binding,
                 );
 
-                let range_type = StaticType::Iterator(Box::new(StaticType::Int));
-                if index_type.is_subtype(&range_type)
+                if Self::index_type_is_slice(&index_type)
                     && let StaticType::List(element) = &type_of_index_target
                 {
                     return Ok(StaticType::List(element.clone()));
@@ -664,6 +663,12 @@ impl Analyser {
                 StaticType::Any
             }
         }
+    }
+
+    /// An index expression typed as an integer sequence (e.g. `0..2`) selects
+    /// a slice of the container rather than a single element.
+    fn index_type_is_slice(index_type: &StaticType) -> bool {
+        index_type.is_subtype(&StaticType::Iterator(Box::new(StaticType::Int)))
     }
 
     /// Specialized `op=` implementations preserve the concrete left type.
@@ -715,12 +720,11 @@ impl Analyser {
                     return;
                 }
 
-                let range_type = StaticType::Iterator(Box::new(StaticType::Int));
                 let is_slice = self
                     .result
                     .expr_types
                     .get(&index.id)
-                    .is_some_and(|index_type| index_type.is_subtype(&range_type));
+                    .is_some_and(Self::index_type_is_slice);
                 let (stored_element_type, value_element_type) = if is_slice {
                     let Some(stored_element_type) = stored_type.index_element_type() else {
                         self.emit(AnalysisError::mismatched_types(

--- a/ndc_vm/src/compiler.rs
+++ b/ndc_vm/src/compiler.rs
@@ -39,7 +39,7 @@ impl Compiler {
         expressions: impl Iterator<Item = ExpressionLocation>,
     ) -> Result<CompiledFunction, CompileError> {
         let mut compiler = Self::default();
-        compiler.compile_batch(expressions.collect())?;
+        compiler.compile_batch(expressions)?;
         Ok(compiler.finish()?.0)
     }
 
@@ -53,7 +53,7 @@ impl Compiler {
             optimize: false,
             ..Default::default()
         };
-        compiler.compile_batch(expressions.collect())?;
+        compiler.compile_batch(expressions)?;
         Ok(compiler.finish()?.0)
     }
 
@@ -72,7 +72,7 @@ impl Compiler {
             optimize: false,
             ..Default::default()
         };
-        compiler.compile_batch(expressions.collect())?;
+        compiler.compile_batch(expressions)?;
         compiler.finish()
     }
 
@@ -88,11 +88,14 @@ impl Compiler {
         new_expressions: impl Iterator<Item = ExpressionLocation>,
     ) -> Result<(CompiledFunction, Self), CompileError> {
         let mut compiler = self; // checkpoint has no trailing Halt
-        compiler.compile_batch(new_expressions.collect())?;
+        compiler.compile_batch(new_expressions)?;
         compiler.finish()
     }
 
-    fn compile_batch(&mut self, expressions: Vec<ExpressionLocation>) -> Result<(), CompileError> {
+    fn compile_batch(
+        &mut self,
+        expressions: impl Iterator<Item = ExpressionLocation>,
+    ) -> Result<(), CompileError> {
         for expression in expressions {
             self.compile_expr(expression)?;
         }


### PR DESCRIPTION
Follow-ups from the review of #192, stacked on #193. The review's bigger findings (fuzzer metadata wiring) were made obsolete by the temp-layout refactor in #193; these are the pieces that survived.

## Changes

- **analyser**: named the `Binding::None` arms in the augmented-assignment plan match (fixes the `match_wildcard_for_single_variants` clippy warning introduced by #192) and extracted the twice-duplicated "index type is an int-range slice" check into `index_type_is_slice`.
- **compiler**: `compile_batch` now takes the expression iterator directly instead of forcing every caller to `.collect()` into a `Vec` first.
- **manual**: the augmented-assignment page only documented variable targets; added sections for indexed/slice/string targets, the once-each evaluation-order guarantee, and the type-checking rules (in-place operators preserve the target type, fallback operators may widen). All new examples are verified to run.

Remaining clippy warnings (`chunk.rs` `use_self`, `only_used_in_recursion`, doc backticks) pre-date this stack on master and are left for a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)