### PR TITLE
fix(ci): run checks for stacked pull requests 🔧

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary

- run the Rust workflow for pull requests targeting any base branch
- keep push-triggered builds limited to `master`
- enable build statuses for stacked pull requests

## Validation

- inspected the resulting workflow diff with `git diff --check`

## AI disclosure

OpenAI Codex (GPT-5) was used to diagnose the workflow trigger, make the configuration change, and draft this PR description.