### PR TITLE
refactor(parser): resolve type annotations in the analyser 🧭

### DIFF
--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -3,11 +3,12 @@ use std::fmt::Debug;
 
 use crate::scope::{CallKind, ResolvedCall, ScopeTree, TypeBinding};
 use itertools::{Itertools, izip};
+use ndc_core::static_type::StaticTypeConstructionError;
 use ndc_core::{StaticType, TypeSignature};
 use ndc_lexer::Span;
 use ndc_parser::{
     AugmentedAssignmentPlan, Binding, Candidate, Expression, ExpressionLocation, ForBody,
-    ForIteration, FunctionParameter, Lvalue, NodeId,
+    ForIteration, FunctionParameter, Lvalue, NodeId, TypeExpr,
 };
 
 /// Side table holding semantic information keyed by AST node identity.
@@ -72,6 +73,33 @@ impl Analyser {
     /// Record an error from outside the analyser (e.g. a hard error caught by the caller).
     pub fn emit_external(&mut self, err: AnalysisError) {
         self.errors.push(err);
+    }
+
+    /// Resolves a syntactic type annotation to a `StaticType`: `Int` becomes
+    /// `StaticType::Int`, `Map<String, Int>` becomes `StaticType::Map { .. }`.
+    /// An unknown name or a wrong generic-argument count is reported as an
+    /// analysis error at the annotation's span, and the annotation falls back
+    /// to `Any` so the rest of the program is still checked.
+    fn lower_type_expr(&mut self, expr: &TypeExpr) -> StaticType {
+        match expr {
+            TypeExpr::Tuple { elements, .. } => {
+                StaticType::Tuple(elements.iter().map(|e| self.lower_type_expr(e)).collect())
+            }
+            TypeExpr::Name { name, args, span } => {
+                let args = args.iter().map(|a| self.lower_type_expr(a)).collect();
+                match StaticType::from_name_and_args(name, args) {
+                    Ok(typ) => typ,
+                    Err(err) => {
+                        self.emit(AnalysisError::invalid_type_annotation(&err, *span));
+                        StaticType::Any
+                    }
+                }
+            }
+        }
+    }
+
+    fn lower_annotation(&mut self, annotation: Option<&TypeExpr>) -> Option<StaticType> {
+        annotation.map(|expr| self.lower_type_expr(expr))
     }
 
     /// Returns `true` if any errors have been recorded during the current
@@ -155,12 +183,13 @@ impl Analyser {
                 annotated_type,
                 value,
             } => {
+                let annotated_type = self.lower_annotation(annotated_type.as_ref());
                 let value_span = value.span;
                 let found_type = self.analyse_or_any(value);
 
                 self.resolve_lvalue_declarative(
                     l_value,
-                    annotated_type.to_owned(),
+                    annotated_type,
                     found_type.clone(),
                     value_span,
                 );
@@ -268,10 +297,17 @@ impl Analyser {
                 resolved_name,
                 parameters,
                 body,
-                return_type: return_type_slot,
+                return_annotation,
+                resolved_return_type,
                 captures,
                 ..
             } => {
+                for param in parameters.iter_mut() {
+                    param.resolved_type = self.lower_annotation(param.annotation.as_ref());
+                }
+                *resolved_return_type = self.lower_annotation(return_annotation.as_ref());
+                let return_type_slot: &Option<StaticType> = resolved_return_type;
+
                 let type_signature = FunctionParameter::from_params(parameters);
 
                 // Pre-register the function before analysing its body so recursive calls can
@@ -939,6 +975,13 @@ pub struct AnalysisError {
 impl AnalysisError {
     pub fn span(&self) -> Span {
         self.span
+    }
+
+    fn invalid_type_annotation(err: &StaticTypeConstructionError, span: Span) -> Self {
+        Self {
+            text: format!("{err}. {}", err.help_text()),
+            span,
+        }
     }
 
     fn tuple_arity_mismatch(ident_len: usize, annotation_len: usize, span: Span) -> Self {

--- a/ndc_lsp/src/features/symbols.rs
+++ b/ndc_lsp/src/features/symbols.rs
@@ -33,7 +33,7 @@ fn collect_symbol(
         Expression::FunctionDeclaration {
             name: Some(name),
             parameters,
-            return_type,
+            resolved_return_type,
             body,
             ..
         } => {
@@ -41,7 +41,7 @@ fn collect_symbol(
             collect_children(body, text, line_index, &mut children);
             out.push(make_symbol(
                 name.clone(),
-                Some(signature(parameters, return_type.as_ref())),
+                Some(signature(parameters, resolved_return_type.as_ref())),
                 SymbolKind::FUNCTION,
                 expr.span,
                 expr.span,

--- a/ndc_lsp/src/visitor.rs
+++ b/ndc_lsp/src/visitor.rs
@@ -222,7 +222,7 @@ fn walk_expression(visitor: &mut impl AstVisitor, expr: &ExpressionLocation) {
             walk_expression(visitor, value);
         }
         Expression::FunctionDeclaration {
-            return_type,
+            resolved_return_type,
             parameters,
             parameters_span,
             body,
@@ -231,7 +231,11 @@ fn walk_expression(visitor: &mut impl AstVisitor, expr: &ExpressionLocation) {
             for p in parameters {
                 walk_lvalue(visitor, &p.lvalue, p.annotation.is_some());
             }
-            visitor.on_function_declaration(return_type.as_ref(), *parameters_span, expr.id);
+            visitor.on_function_declaration(
+                resolved_return_type.as_ref(),
+                *parameters_span,
+                expr.id,
+            );
             walk_expression(visitor, body);
         }
         Expression::Statement(inner) | Expression::Grouping(inner) => {

--- a/ndc_parser/src/expression.rs
+++ b/ndc_parser/src/expression.rs
@@ -1,5 +1,6 @@
 use crate::operator::LogicalOperator;
 use crate::parser::Error as ParseError;
+use crate::type_expr::TypeExpr;
 use ndc_core::{StaticType, TypeSignature};
 use ndc_lexer::Span;
 use num::BigInt;
@@ -110,7 +111,7 @@ pub enum Expression {
     Grouping(Box<ExpressionLocation>),
     VariableDeclaration {
         l_value: Lvalue,
-        annotated_type: Option<StaticType>,
+        annotated_type: Option<TypeExpr>,
         value: Box<ExpressionLocation>,
     },
     Assignment {
@@ -129,7 +130,8 @@ pub enum Expression {
         parameters: Vec<FunctionParameter>,
         parameters_span: Span,
         body: Box<ExpressionLocation>,
-        return_type: Option<StaticType>,
+        return_annotation: Option<TypeExpr>,
+        resolved_return_type: Option<StaticType>,
         captures: Vec<CaptureSource>,
         pure: bool,
     },
@@ -213,7 +215,8 @@ pub enum ForBody {
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct FunctionParameter {
     pub lvalue: Lvalue,
-    pub annotation: Option<StaticType>,
+    pub annotation: Option<TypeExpr>,
+    pub resolved_type: Option<StaticType>,
     pub span: Span,
 }
 
@@ -229,7 +232,7 @@ impl FunctionParameter {
                             p.lvalue
                         );
                     };
-                    (identifier.clone(), p.annotation.clone())
+                    (identifier.clone(), p.resolved_type.clone())
                 })
                 .collect(),
         )

--- a/ndc_parser/src/lib.rs
+++ b/ndc_parser/src/lib.rs
@@ -1,6 +1,7 @@
 mod expression;
 mod operator;
 mod parser;
+mod type_expr;
 
 pub use expression::{
     AugmentedAssignmentPlan, Binding, Candidate, CaptureSource, Expression, ExpressionLocation,
@@ -9,3 +10,4 @@ pub use expression::{
 pub use operator::{BinaryOperator, LogicalOperator, UnaryOperator};
 pub use parser::Error;
 pub use parser::Parser;
+pub use type_expr::TypeExpr;

--- a/ndc_parser/src/parser.rs
+++ b/ndc_parser/src/parser.rs
@@ -6,6 +6,7 @@ use crate::expression::{
     Lvalue, NodeId,
 };
 use crate::operator::{BinaryOperator, LogicalOperator, UnaryOperator};
+use crate::type_expr::TypeExpr;
 use ndc_core::{Parameter, StaticType, TypeSignature};
 use ndc_lexer::{Span, Token, TokenLocation};
 
@@ -1190,9 +1191,9 @@ impl Parser {
         )?;
 
         // Optional return type annotation: `-> Type`
-        let annotated_return_type = if self.peek_current_token() == Some(&Token::RightArrow) {
+        let return_annotation = if self.peek_current_token() == Some(&Token::RightArrow) {
             self.advance();
-            Some(self.static_type()?)
+            Some(self.type_annotation()?)
         } else {
             None
         };
@@ -1222,7 +1223,8 @@ impl Parser {
                 parameters: argument_list,
                 parameters_span,
                 body: Box::new(body),
-                return_type: annotated_return_type,
+                return_annotation,
+                resolved_return_type: None,
                 resolved_name: None,
                 captures: vec![],
                 pure: is_pure,
@@ -1330,7 +1332,7 @@ impl Parser {
         Ok(Expression::Map { values, default }.to_location(map_open_span.merge(map_close_span)))
     }
 
-    pub fn static_type(&mut self) -> Result<StaticType, Error> {
+    pub fn type_annotation(&mut self) -> Result<TypeExpr, Error> {
         let Some(TokenLocation { token, span }) = self.peek_current_token_location() else {
             return Err(Error::end_of_input(
                 self.tokens.last().expect("last token exists").span,
@@ -1348,7 +1350,7 @@ impl Parser {
         }
     }
 
-    pub fn named_or_generic_type(&mut self) -> Result<StaticType, Error> {
+    pub fn named_or_generic_type(&mut self) -> Result<TypeExpr, Error> {
         let Ok(TokenLocation {
             token: Token::Identifier(ident),
             span,
@@ -1357,32 +1359,37 @@ impl Parser {
             unreachable!("this should have been checked");
         };
 
-        let generic_args = if self.peek_current_token() == Some(&Token::Less) {
-            self.delimited_type_params()?
+        let (args, span) = if self.peek_current_token() == Some(&Token::Less) {
+            let (args, close_span) = self.delimited_type_params()?;
+            (args, span.merge(close_span))
         } else {
-            Vec::new()
+            (Vec::new(), span)
         };
 
-        StaticType::from_name_and_args(ident.as_str(), generic_args)
-            .map_err(|err| Error::with_help(err.to_string(), span, err.help_text().to_string()))
+        Ok(TypeExpr::Name {
+            name: ident,
+            args,
+            span,
+        })
     }
 
     /// Parses `<T, U, ...>` type parameter lists, handling the `>>` / `>=` / `>>=`
-    /// ambiguity that arises with nested generics like `List<List<Int>>`.
-    fn delimited_type_params(&mut self) -> Result<Vec<StaticType>, Error> {
+    /// ambiguity that arises with nested generics like `List<List<Int>>`. Returns
+    /// the parsed items and the span of the closing `>`.
+    fn delimited_type_params(&mut self) -> Result<(Vec<TypeExpr>, Span), Error> {
         self.require_current_token_matches(&Token::Less)?;
 
-        let mut items = vec![self.static_type()?];
+        let mut items = vec![self.type_annotation()?];
 
         while self.consume_token_if(&[Token::Comma]).is_some() {
             if self.peek_current_token() == Some(&Token::Greater) {
                 break;
             }
-            items.push(self.static_type()?);
+            items.push(self.type_annotation()?);
         }
 
-        self.consume_closing_angle_bracket()?;
-        Ok(items)
+        let close_span = self.consume_closing_angle_bracket()?;
+        Ok((items, close_span))
     }
 
     /// Consumes a closing `>` for a generic type parameter list. If the current
@@ -1430,14 +1437,14 @@ impl Parser {
         Ok(greater_span)
     }
 
-    pub fn tuple_type(&mut self) -> Result<StaticType, Error> {
-        let (types, _span) = self.delimited_comma_separated(
+    pub fn tuple_type(&mut self) -> Result<TypeExpr, Error> {
+        let (elements, span) = self.delimited_comma_separated(
             &Token::LeftParentheses,
             &Token::RightParentheses,
-            Self::static_type,
+            Self::type_annotation,
             true,
         )?;
-        Ok(StaticType::Tuple(types))
+        Ok(TypeExpr::Tuple { elements, span })
     }
 
     fn named_parameter(&mut self) -> Result<FunctionParameter, Error> {
@@ -1454,7 +1461,7 @@ impl Parser {
 
         let annotation = if self.peek_current_token() == Some(&Token::Colon) {
             self.advance();
-            Some(self.static_type()?)
+            Some(self.type_annotation()?)
         } else {
             None
         };
@@ -1468,11 +1475,12 @@ impl Parser {
         Ok(FunctionParameter {
             lvalue,
             annotation,
+            resolved_type: None,
             span,
         })
     }
 
-    pub fn named_binding(&mut self) -> Result<(Lvalue, Option<StaticType>), Error> {
+    pub fn named_binding(&mut self) -> Result<(Lvalue, Option<TypeExpr>), Error> {
         let maybe_lvalue = self.tuple_expression(Self::single_expression, false)?;
         let lvalue_span = maybe_lvalue.span;
 
@@ -1486,7 +1494,7 @@ impl Parser {
 
         let annotated_type = if self.peek_current_token() == Some(&Token::Colon) {
             self.advance();
-            Some(self.static_type()?)
+            Some(self.type_annotation()?)
         } else {
             None
         };

--- a/ndc_parser/src/type_expr.rs
+++ b/ndc_parser/src/type_expr.rs
@@ -1,0 +1,57 @@
+use ndc_lexer::Span;
+use std::fmt;
+
+/// A type annotation exactly as written in the source: `Int`, `Map<String, Int>`,
+/// `(Int, String)`. Purely syntactic — names are not validated and carry no
+/// meaning here; every node keeps the span of the source text it was parsed from.
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum TypeExpr {
+    /// A (possibly generic) named type: `Int`, `List<Int>`, `Map<String, Int>`.
+    Name {
+        name: String,
+        args: Vec<Self>,
+        span: Span,
+    },
+    /// A tuple type: `(Int, String)`. The unit type `()` is the empty tuple.
+    Tuple { elements: Vec<Self>, span: Span },
+}
+
+impl TypeExpr {
+    #[must_use]
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Name { span, .. } | Self::Tuple { span, .. } => *span,
+        }
+    }
+}
+
+impl fmt::Display for TypeExpr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fn join(f: &mut fmt::Formatter<'_>, items: &[TypeExpr]) -> fmt::Result {
+            for (idx, item) in items.iter().enumerate() {
+                if idx > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, "{item}")?;
+            }
+            Ok(())
+        }
+
+        match self {
+            Self::Name { name, args, .. } => {
+                write!(f, "{name}")?;
+                if !args.is_empty() {
+                    write!(f, "<")?;
+                    join(f, args)?;
+                    write!(f, ">")?;
+                }
+                Ok(())
+            }
+            Self::Tuple { elements, .. } => {
+                write!(f, "(")?;
+                join(f, elements)?;
+                write!(f, ")")
+            }
+        }
+    }
+}

--- a/ndc_vm/src/compiler.rs
+++ b/ndc_vm/src/compiler.rs
@@ -300,7 +300,7 @@ impl Compiler {
                 resolved_name,
                 body,
                 parameters,
-                return_type,
+                resolved_return_type,
                 captures,
                 pure,
                 ..
@@ -311,7 +311,7 @@ impl Compiler {
                     resolved_name,
                     *body,
                     &type_signature,
-                    return_type,
+                    resolved_return_type,
                     captures,
                     pure,
                     span,

--- a/tests/functional/programs/004_basic/056_unknown_type_in_let_annotation.ndc
+++ b/tests/functional/programs/004_basic/056_unknown_type_in_let_annotation.ndc
@@ -1,0 +1,2 @@
+// expect-error: unknown type `Unknwn`
+let x: Unknwn = 1;

--- a/tests/functional/programs/004_basic/057_generic_arity_error_in_annotation.ndc
+++ b/tests/functional/programs/004_basic/057_generic_arity_error_in_annotation.ndc
@@ -1,0 +1,2 @@
+// expect-error: type `Map` expects exactly 2 generic arguments
+let a: Map<Int> = %{};

--- a/tests/functional/programs/004_basic/058_bad_annotation_does_not_stop_analysis.ndc
+++ b/tests/functional/programs/004_basic/058_bad_annotation_does_not_stop_analysis.ndc
@@ -1,0 +1,5 @@
+// A bad type annotation is a recoverable analysis error: the analyser keeps
+// going, so the unrelated error on the next line is reported as well.
+// expect-error: Identifier undefined_variable has not previously been declared
+let x: Unknwn = 1;
+undefined_variable

--- a/tests/functional/programs/005_functions/039_unknown_type_in_param_annotation.ndc
+++ b/tests/functional/programs/005_functions/039_unknown_type_in_param_annotation.ndc
@@ -1,0 +1,2 @@
+// expect-error: unknown type `Unknwn`
+fn f(x: Unknwn) => x

--- a/tests/functional/programs/005_functions/040_unknown_type_in_return_annotation.ndc
+++ b/tests/functional/programs/005_functions/040_unknown_type_in_return_annotation.ndc
@@ -1,0 +1,2 @@
+// expect-error: unknown type `Unknwn`
+fn f(x) -> Unknwn { x }

--- a/tests/functional/tests/repl.rs
+++ b/tests/functional/tests/repl.rs
@@ -181,3 +181,25 @@ fn vm_error_rolls_back_failed_declaration() {
         "unexpected error: {err:?}"
     );
 }
+
+#[test]
+fn unknown_annotation_errors_without_corrupting_state() {
+    let mut interp = {
+        let mut i = Interpreter::capturing();
+        i.configure(ndc_stdlib::register);
+        i
+    };
+    interp.eval("let x = 42;").unwrap();
+    let err = interp
+        .eval("let y: Unknwn = 1;")
+        .expect_err("unknown type should error");
+    assert!(
+        format!("{err:?}").contains("unknown type `Unknwn`"),
+        "unexpected error: {err:?}"
+    );
+    // The failed line must not leak `y` into scope, and `x` must still work.
+    assert!(interp.eval("y").is_err());
+    interp.eval("print(x)").unwrap();
+    let out = String::from_utf8(interp.get_output().unwrap()).unwrap();
+    assert_eq!(out.trim(), "42");
+}


### PR DESCRIPTION
## Context

Working on PR #197's biggest TODO ("struct names are not usable as types") revealed the underlying problem: the parser eagerly constructs semantic `StaticType`s from annotations through a closed-world name table (`StaticType::from_name_and_args`). That makes user-declared type names unresolvable in principle (the parser only has tokens), turns a typo in one annotation into a fatal parse error that blanks every LSP feature for the document, loses the annotation's span, and blocks the planned generics rework — a type variable is a binder, not a name lookup, so it can't be represented by parse-time `StaticType` construction.

This precursor separates type syntax from type semantics so struct names (and later, type variables) become a small addition to one lowering function instead of a special case.

## Changes

- **`ndc_parser`**: new syntactic `TypeExpr` (`Name { name, args, span }` / `Tuple { elements, span }`) with `Display`. The type-annotation parser builds `TypeExpr` and no longer validates names; the `>>`/`>=`/`>>=` splitting is untouched. AST slots store the syntax plus an analyser-filled resolved field (the existing `Binding::Resolved`-style pattern): `FunctionParameter.resolved_type` and `FunctionDeclaration.resolved_return_type`.
- **`ndc_analyser`**: `lower_type_expr` resolves `TypeExpr` → `StaticType`. Unknown names and generic-arity mismatches are emitted as span-precise analysis errors and degrade to `Any`, so the rest of the program is still checked. Lowering runs before the `TypeSignature` is built, so overload resolution and runtime dispatch see the resolved types.
- **`ndc_vm` / `ndc_lsp`**: consume the resolved fields instead of parse-time types.

## Behaviour change

`fn f(x: Unknown)` and `let a: Map<Int> = ...` now report `error[resolver]` diagnostics (with the annotation's exact span) instead of aborting the parse, and one bad annotation no longer suppresses other errors or LSP features. New functional and REPL tests cover each annotation position, the arity error, error recovery, and REPL state integrity.

🤖
