### PR TITLE
fix: harden struct parsing, copying, and tooling after review 🛡️

### DIFF
--- a/manual/src/reference/types/struct.md
+++ b/manual/src/reference/types/struct.md
@@ -31,8 +31,9 @@ struct Person {
 struct Marker { }
 ```
 
-A struct declaration is a statement, like `let` — it cannot appear in value
-position (`let s = struct P { x: Int }` is a parse error).
+Declare a struct on its own line, like a `let` declaration — at the top level of
+a program, inside a block, or in the REPL. A struct cannot be declared in the
+middle of another expression, so `let s = struct P { x: Int }` is an error.
 
 Struct names are globally unique: declaring two structs with the same name is an
 error, even in different scopes.

--- a/manual/src/reference/types/struct.md
+++ b/manual/src/reference/types/struct.md
@@ -31,6 +31,9 @@ struct Person {
 struct Marker { }
 ```
 
+A struct declaration is a statement, like `let` — it cannot appear in value
+position (`let s = struct P { x: Int }` is a parse error).
+
 Struct names are globally unique: declaring two structs with the same name is an
 error, even in different scopes.
 
@@ -102,6 +105,18 @@ assert_eq(Foo(1).size, 1);
 assert_eq(Bar(10).size, 10);
 ```
 
+Because `s.f()` is method-call syntax, calling a *function stored in a field*
+needs parentheses around the member access: `(s.f)()` first evaluates `s.f`
+(the getter) and then calls its result.
+
+```ndc
+struct Callback { f: Any }
+let cb = Callback(fn (a) => a * 2);
+
+cb.f(21);    // ERROR: this is method-call syntax for `f(cb, 21)`
+(cb.f)(21)   // 42: reads the field, then calls the stored function
+```
+
 ## Field assignment
 
 `p.x = value` writes to a field. The value must fit the field's declared type:
@@ -147,6 +162,17 @@ let b = a;
 b.x = 99;
 
 assert_eq(a.x, 99);
+```
+
+Use `clone` for an independent instance (nested containers are still shared,
+like cloning a list of lists) or `deepcopy` to duplicate nested mutable state
+as well:
+
+```ndc
+let c = clone(a);
+c.x = 1;
+assert_eq(a.x, 99);
+assert_eq(c.x, 1);
 ```
 
 ## Equality and hashing

--- a/manual/src/troubleshooting/overload-dispatch-collections.md
+++ b/manual/src/troubleshooting/overload-dispatch-collections.md
@@ -7,11 +7,11 @@ call is free of any type-checking overhead at runtime. When it cannot (because a
 inferred as `Any`), the VM performs **dynamic dispatch**: it tests each candidate overload at
 runtime to find the best match.
 
-The reverse also holds: when every argument type is known at compile time and **no** overload
-can accept them — every candidate has a fully-annotated signature of the wrong arity or with
-conflicting parameter types — the call is rejected at compile time with a
-`No function called '…' found that matches the arguments` error, instead of being deferred to
-a guaranteed runtime failure.
+The reverse also holds. Sometimes every argument type is known at compile time, but no
+overload can accept them: each candidate is fully annotated, and none matches the call's
+arity and argument types. Such a call could only ever fail at runtime. Instead of waiting
+for that, it is rejected at compile time with a
+`No function called '…' found that matches the arguments` error.
 
 ## O(1) dispatch guarantee
 

--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -671,39 +671,25 @@ impl Analyser {
                 );
                 *resolved = Some(struct_id);
 
-                // Create a constructor
+                // Bind the constructor and per-field accessors with the same
+                // types the runtime functions report (StructInfo is the source
+                // of truth), so static bindings and runtime dispatch agree.
+                let info = Rc::clone(&self.struct_registry.borrow()[struct_id]);
+
                 *resolved_name = Some(self.scope_tree.create_local_binding(
                     name.clone(),
-                    TypeBinding::Annotated(StaticType::Function {
-                        parameters: Some(field_types.clone()),
-                        return_type: Box::new(StaticType::Struct {
-                            id: struct_id,
-                            name: Box::from(name.as_str()),
-                        }),
-                    }),
+                    TypeBinding::Annotated(info.constructor_type()),
                 ));
 
-                for (field, field_type) in fields.iter_mut().zip(&field_types) {
-                    // Getter
+                for (index, field) in fields.iter_mut().enumerate() {
                     field.resolved_getter = Some(self.scope_tree.create_local_binding(
                         field.identifier.clone(),
-                        TypeBinding::Annotated(StaticType::Function {
-                            parameters: Some(vec![
-                                self.struct_registry.borrow()[struct_id].static_type(),
-                            ]),
-                            return_type: Box::new(field_type.clone()),
-                        }),
+                        TypeBinding::Annotated(info.getter_type(index)),
                     ));
 
                     field.resolved_setter = Some(self.scope_tree.create_local_binding(
                         format!("{}=", field.identifier),
-                        TypeBinding::Annotated(StaticType::Function {
-                            parameters: Some(vec![
-                                self.struct_registry.borrow()[struct_id].static_type(),
-                                field_type.clone(),
-                            ]),
-                            return_type: Box::new(StaticType::unit()),
-                        }),
+                        TypeBinding::Annotated(info.setter_type(index)),
                     ));
                 }
 

--- a/ndc_bin/src/highlighter.rs
+++ b/ndc_bin/src/highlighter.rs
@@ -66,6 +66,7 @@ impl AndycppHighlighter {
                 // Keywords — coral red
                 Token::Let
                 | Token::Fn
+                | Token::Struct
                 | Token::If
                 | Token::Else
                 | Token::Return

--- a/ndc_lsp/src/features/completion.rs
+++ b/ndc_lsp/src/features/completion.rs
@@ -136,7 +136,8 @@ fn format_function_signature(typ: &StaticType, is_dot: bool) -> (String, String)
 
 /// Language keywords offered in general (non-dot) completion.
 const KEYWORDS: &[&str] = &[
-    "let", "fn", "if", "else", "while", "for", "in", "return", "break", "continue", "true", "false",
+    "let", "fn", "struct", "if", "else", "while", "for", "in", "return", "break", "continue",
+    "true", "false",
 ];
 
 fn keyword_completions() -> impl Iterator<Item = CompletionItem> {

--- a/ndc_parser/src/expression.rs
+++ b/ndc_parser/src/expression.rs
@@ -365,9 +365,9 @@ impl Lvalue {
             Expression::List { values } | Expression::Tuple { values } => values
                 .iter()
                 .all(|el| Self::can_build_destructure_from_expression(&el.expression)),
-            Expression::Grouping(inner) => {
-                Self::can_build_destructure_from_expression(&inner.expression)
-            }
+            // Parentheses around an lvalue are transparent: `(s.x) = 5` writes
+            // the same location as `s.x = 5`.
+            Expression::Grouping(inner) => Self::can_build_from_expression(&inner.expression),
             _ => false,
         }
     }
@@ -444,7 +444,7 @@ impl TryFrom<ExpressionLocation> for Lvalue {
                     .map(Self::try_from)
                     .collect::<Result<Vec<Self>, Self::Error>>()?,
             )),
-            Expression::Grouping(value) => Ok(Self::Sequence(vec![Self::try_from(*value)?])),
+            Expression::Grouping(value) => Self::try_from(*value),
             _expr => Err(ParseError::text("invalid l-value".to_string(), value.span)),
         }
     }

--- a/ndc_parser/src/parser.rs
+++ b/ndc_parser/src/parser.rs
@@ -296,6 +296,8 @@ impl Parser {
     fn expression_or_statement(&mut self) -> Result<ExpressionLocation, Error> {
         let mut expression = if self.match_token(&[Token::Let]).is_some() {
             self.let_statement()?
+        } else if self.match_token(&[Token::Struct]).is_some() {
+            self.struct_declaration()?
         } else {
             self.expression()?
         };
@@ -923,7 +925,25 @@ impl Parser {
     /// x in xs
     /// ```
     fn for_iteration(&mut self) -> Result<ForIteration, Error> {
-        let l_value = Lvalue::try_from(self.tuple_expression(Self::primary, false)?)?;
+        let maybe_lvalue = self.tuple_expression(Self::primary, false)?;
+        let lvalue_span = maybe_lvalue.span;
+        let l_value = Lvalue::try_from(maybe_lvalue)?;
+
+        if let Some(target) = l_value.non_binding_target() {
+            let help = match target {
+                NonBindingTarget::Member => {
+                    "A for loop introduces a new binding for each iteration; a struct field like `foo.bar` cannot be an iteration variable."
+                }
+                NonBindingTarget::Index => {
+                    "A for loop introduces a new binding for each iteration; an indexed element like `foo[index]` cannot be an iteration variable."
+                }
+            };
+            return Err(Error::with_help(
+                "Invalid iteration variable".to_string(),
+                lvalue_span,
+                help.to_string(),
+            ));
+        }
 
         self.require_current_token_matches(&Token::In)?;
 
@@ -952,10 +972,6 @@ impl Parser {
         // matches function declarations like `fn function_name(arg1, arg2) { }`
         else if self.match_token(&[Token::Fn, Token::Pure]).is_some() {
             return self.function_declaration();
-        }
-        // Matches the start of a struct declaration
-        else if self.match_token(&[Token::Struct]).is_some() {
-            return self.struct_declaration();
         }
         // matches `return;` and `return (expression);`
         else if let Some(return_token_location) = self.consume_token_if(&[Token::Return]) {
@@ -1003,8 +1019,16 @@ impl Parser {
             let mut grouped = self.expression()?;
 
             let end_parentheses = self.require_current_token_matches(&Token::RightParentheses)?;
-            grouped.span = start_parentheses.span.merge(end_parentheses.span);
+            let span = start_parentheses.span.merge(end_parentheses.span);
 
+            // Parenthesized member access keeps its Grouping wrapper so the
+            // postfix-call rewrite can tell `(s.f)()` (call the field's value)
+            // apart from `s.f()` (method call, lowered to `f(s)`).
+            if matches!(grouped.expression, Expression::MemberAccess { .. }) {
+                return Ok(Expression::Grouping(Box::new(grouped)).to_location(span));
+            }
+
+            grouped.span = span;
             return Ok(grouped);
         }
 
@@ -1519,7 +1543,7 @@ impl Parser {
         let maybe_lvalue = self.single_expression()?;
         let lvalue_span = maybe_lvalue.span;
 
-        let Ok(lvalue) = Lvalue::try_from(maybe_lvalue) else {
+        let Ok(lvalue @ Lvalue::Identifier { .. }) = Lvalue::try_from(maybe_lvalue) else {
             return Err(Error::with_help(
                 "Expected parameter name".to_string(),
                 lvalue_span,

--- a/ndc_vm/src/value/mod.rs
+++ b/ndc_vm/src/value/mod.rs
@@ -184,9 +184,10 @@ impl Value {
     }
 
     /// Creates a shallow copy: scalars are copied by value; mutable collection
-    /// types (String, List, Map, Deque, heaps) get new independent containers
-    /// with cloned contents; immutable / identity types (Tuple, Function,
-    /// Iterator, `BigInt`, Rational, Complex, Some, `OverloadSet`) share the Rc.
+    /// types (String, List, Map, Deque, heaps, structs) get new independent
+    /// containers with cloned contents; immutable / identity types (Tuple,
+    /// Function, Iterator, `BigInt`, Rational, Complex, Some, `OverloadSet`)
+    /// share the Rc.
     pub fn shallow_clone(&self) -> Self {
         match self {
             Self::Object(obj) => match obj.as_ref() {
@@ -208,6 +209,10 @@ impl Value {
                 Object::Map { entries, default } => Self::Object(Rc::new(Object::Map {
                     entries: RefCell::new(entries.borrow().clone()),
                     default: default.clone(),
+                })),
+                Object::Struct { info, fields } => Self::Object(Rc::new(Object::Struct {
+                    info: Rc::clone(info),
+                    fields: RefCell::new(fields.borrow().clone()),
                 })),
                 _ => Self::Object(obj.clone()),
             },
@@ -447,6 +452,10 @@ impl Object {
             )),
             Self::MinHeap(refcell) => Self::MinHeap(RefCell::new(refcell.borrow().clone())),
             Self::MaxHeap(refcell) => Self::MaxHeap(RefCell::new(refcell.borrow().clone())),
+            Self::Struct { info, fields } => Self::Struct {
+                info: Rc::clone(info),
+                fields: RefCell::new(fields.borrow().iter().map(Value::deep_copy).collect()),
+            },
             // Iterator: deep_copy if supported, otherwise share the Rc.
             Self::Iterator(shared) => {
                 if let Some(copy) = shared.borrow().deep_copy() {

--- a/tests/functional/programs/005_functions/041_member_as_parameter_error.ndc
+++ b/tests/functional/programs/005_functions/041_member_as_parameter_error.ndc
@@ -1,0 +1,6 @@
+// Function parameters must be plain identifiers. A member access used to
+// panic the parser's parameter conversion.
+// expect-error: Expected parameter name
+struct P { x: Int }
+let p = P(1);
+fn f(p.x) { 1 }

--- a/tests/functional/programs/015_struct/025_field_as_iteration_variable_error.ndc
+++ b/tests/functional/programs/015_struct/025_field_as_iteration_variable_error.ndc
@@ -1,0 +1,6 @@
+// A for loop introduces a new binding per iteration, so a struct field is not
+// a valid iteration variable. This used to panic the compiler.
+// expect-error: Invalid iteration variable
+struct Point { x: Int }
+let p = Point(1);
+for (p.x) in [1, 2, 3] { }

--- a/tests/functional/programs/015_struct/026_declaration_in_value_position_error.ndc
+++ b/tests/functional/programs/015_struct/026_declaration_in_value_position_error.ndc
@@ -1,0 +1,4 @@
+// Struct declarations are statements, like `let`. Using one in value position
+// used to corrupt the VM stack (the declaration pushes no value).
+// expect-error: Expected an expression but got 'struct' instead
+let l = [struct R { x: Int }, 5];

--- a/tests/functional/programs/015_struct/027_call_function_stored_in_field.ndc
+++ b/tests/functional/programs/015_struct/027_call_function_stored_in_field.ndc
@@ -1,0 +1,22 @@
+// `s.f()` is method-call syntax (it lowers to `f(s)`), so calling a function
+// stored in a field requires parentheses: `(s.f)()` evaluates the getter and
+// calls its result. This used to silently lower to `f(s)` as well.
+struct S { f: Any, n: Int }
+let s = S(fn (a) => a * 2, 5);
+
+assert_eq((s.f)(21), 42);
+assert_eq(((s.f))(3), 6);
+
+// A stored function can still be lifted into a variable first.
+let g = (s.f);
+assert_eq(g(4), 8);
+
+// Parentheses around the receiver (not the whole member access) keep
+// method-call semantics.
+assert_eq((s).n, 5);
+
+// Parentheses around an lvalue are transparent for assignment.
+(s.n) = 7;
+assert_eq(s.n, 7);
+(s.n) += 3;
+assert_eq(s.n, 10);

--- a/tests/functional/programs/015_struct/028_clone_and_deepcopy.ndc
+++ b/tests/functional/programs/015_struct/028_clone_and_deepcopy.ndc
@@ -1,0 +1,22 @@
+// Structs are mutable, so clone() must produce an independent instance and
+// deepcopy() must also duplicate nested mutable state. Both used to alias.
+struct P { x: Int }
+let a = P(1);
+let b = clone(a);
+b.x = 99;
+assert_eq(a.x, 1);
+assert_eq(b.x, 99);
+
+struct Holder { items: List<Int> }
+let h = Holder([1]);
+
+// clone is shallow: the instance is independent but nested containers are shared.
+let shallow = clone(h);
+shallow.items.push(2);
+assert_eq(h.items, [1, 2]);
+
+// deepcopy shares nothing.
+let deep = deepcopy(h);
+deep.items.push(3);
+assert_eq(h.items, [1, 2]);
+assert_eq(deep.items, [1, 2, 3]);


### PR DESCRIPTION
## Context

A final adversarial review of #197 (after it merged) surfaced four real bugs and two smaller gaps. This PR fixes all six. Each bug was reproduced before fixing and has a regression test.

## Fixes

- **Compiler panic:** `for (p.x) in [1, 2, 3]` hit `unreachable!("cannot declare into a field")`. For-loop iteration variables now go through the same `non_binding_target` check as `let`. The probe also uncovered that `fn f(p.x)` / `fn f(l[0])` panicked in `FunctionParameter::from_params` (the index case pre-dates structs) — parameters are now required to be plain identifiers at parse time.
- **VM stack corruption:** a struct declaration in value position (`[struct R { x: Int }, 5]` printed `[,5]`) pushed no value. Struct declarations are now statements, parsed exactly like `let`, so value position is a parse error.
- **`(s.f)()` silently called the getter method-style** instead of the function stored in the field. Parenthesized member access now keeps an `Expression::Grouping` wrapper so the postfix-call rewrite can tell it apart from `s.f()`. Grouping was never constructed by the parser before, so its (dead) lvalue arms were redefined as transparent: `(s.x) = 5`, `(s.x) += 2`, and `(l[0]) = 9` behave exactly as before.
- **`clone()` aliased structs and `deepcopy()` shared nested state** — `Object::Struct` fell into both catch-all arms. Structs now copy like the other mutable containers: `clone` gives an independent instance (nested containers shared, like lists), `deepcopy` shares nothing.
- The `struct` keyword was missing from the REPL highlighter and the LSP keyword completion list.
- The analyser hand-built the constructor/getter/setter `StaticType`s inline; it now uses `StructInfo::constructor_type()/getter_type()/setter_type()` — the same source of truth the runtime functions use.

🤖
