### PR TITLE
fix(analyser): resolve struct type names through lexical scopes 🔭

### DIFF
--- a/manual/src/reference/types.md
+++ b/manual/src/reference/types.md
@@ -49,8 +49,9 @@ fn manhattan(p: Point) => p.x + p.y
 let points: List<Point> = [Point(1, 2), Point(3, 4)];
 ```
 
-A struct name refers to the struct declared earlier in the program; it cannot be used
-before (or inside) its own declaration, and declaring two structs with the same name is
-an error.
+A struct name refers to the struct declared earlier in an enclosing scope; it cannot be
+used before (or inside) its own declaration, and it goes out of scope together with the
+block or function that declared it. See [Struct](./types/struct.md) for the scoping
+rules.
 
 > **Note:** `Any` is the base type for every other type, so an `Any`-annotated binding will accept anything. When a parameter or value has no annotation and the analyser can't infer a type, it falls back to `Any`. There is also a `Never` type used internally for things like `break` that don't produce a value — you'll rarely need to write it by hand.

--- a/manual/src/reference/types/struct.md
+++ b/manual/src/reference/types/struct.md
@@ -35,16 +35,28 @@ Declare a struct on its own line, like a `let` declaration — at the top level 
 a program, inside a block, or in the REPL. A struct cannot be declared in the
 middle of another expression, so `let s = struct P { x: Int }` is an error.
 
-Struct names are globally unique: declaring two structs with the same name is an
-error, even in different scopes.
+Struct names are lexically scoped, like variables. Declaring two structs with
+the same name in the same scope is an error, but the name can be reused in
+scopes that never coexist, and a declaration in an inner scope shadows a
+same-named struct from an outer scope.
 
 ```ndc
 struct Point { x: Int }
 struct Point { y: Int } // ERROR: Illegal redefinition of struct 'Point'
 ```
 
+A struct declared inside a function or block goes out of scope with it: the
+type name, the constructor, and the field accessors are all unavailable
+outside.
+
+A struct cannot take the name of a built-in type:
+
+```ndc
+struct Int { x: Float } // ERROR: Struct 'Int' is not allowed to shadow the built-in type 'Int'
+```
+
 A struct can only be used after its declaration, and the name becomes usable as a
-[type annotation](../types.md) everywhere annotations are accepted.
+[type annotation](../types.md) in the scopes where the struct is visible.
 
 ## Constructing instances
 

--- a/ndc_analyser/src/analyser.rs
+++ b/ndc_analyser/src/analyser.rs
@@ -1,4 +1,4 @@
-use crate::scope::{CallKind, ResolvedCall, ScopeTree, TypeBinding};
+use crate::scope::{CallKind, ResolvedCall, ScopeTree, TypeBinding, TypeDef};
 use itertools::{Itertools, izip};
 use ndc_core::static_type::StaticTypeConstructionError;
 use ndc_core::r#struct::StructRegistry;
@@ -99,9 +99,11 @@ impl Analyser {
 
     /// Resolves a syntactic type annotation to a `StaticType`: `Int` becomes
     /// `StaticType::Int`, `Map<String, Int>` becomes `StaticType::Map { .. }`,
-    /// and a declared struct name becomes its `StaticType::Struct`. Built-in
-    /// names take precedence over structs. An unknown name or a wrong
-    /// generic-argument count is reported as an analysis error at the
+    /// and a struct name declared in a surrounding scope becomes its
+    /// `StaticType::Struct`. Type names resolve through the lexical scope
+    /// chain; built-ins live in the global scope and can never be shadowed
+    /// (struct declarations reject built-in names). An unknown name or a
+    /// wrong generic-argument count is reported as an analysis error at the
     /// annotation's span, and the annotation falls back to `Any` so the rest
     /// of the program is still checked.
     fn lower_type_expr(&mut self, expr: &TypeExpr) -> StaticType {
@@ -112,19 +114,21 @@ impl Analyser {
             TypeExpr::Name { name, args, span } => {
                 let has_args = !args.is_empty();
                 let args = args.iter().map(|a| self.lower_type_expr(a)).collect();
-                match StaticType::from_name_and_args(name, args) {
-                    Ok(typ) => typ,
-                    Err(err) => {
-                        let info = self.struct_registry.borrow().find_by_name(name).cloned();
-                        match info {
-                            Some(info) if !has_args => info.static_type(),
-                            Some(_) => {
-                                self.emit(AnalysisError::type_does_not_take_generic_args(
-                                    name, *span,
-                                ));
-                                StaticType::Any
-                            }
-                            None => {
+                match self.scope_tree.resolve_type(name).cloned() {
+                    Some(TypeDef::Struct(info)) => {
+                        if has_args {
+                            self.emit(AnalysisError::type_does_not_take_generic_args(name, *span));
+                            StaticType::Any
+                        } else {
+                            info.static_type()
+                        }
+                    }
+                    // `from_name_and_args` reports wrong generic arity for
+                    // built-ins and "unknown type" for unresolved names.
+                    Some(TypeDef::Builtin) | None => {
+                        match StaticType::from_name_and_args(name, args) {
+                            Ok(typ) => typ,
+                            Err(err) => {
                                 self.emit(AnalysisError::invalid_type_annotation(&err, *span));
                                 StaticType::Any
                             }
@@ -641,7 +645,12 @@ impl Analyser {
                     .map(|f| self.lower_type_expr(&f.annotation))
                     .collect();
 
-                if self.struct_registry.borrow().find_by_name(name).is_some() {
+                if matches!(self.scope_tree.resolve_type(name), Some(TypeDef::Builtin)) {
+                    self.emit(AnalysisError::struct_shadows_builtin(name, *span));
+                    return Ok(StaticType::unit());
+                }
+
+                if self.scope_tree.has_type_in_current_scope(name) {
                     self.emit(AnalysisError::struct_redefinition(name, *span));
                     return Ok(StaticType::unit());
                 }
@@ -675,6 +684,9 @@ impl Analyser {
                 // types the runtime functions report (StructInfo is the source
                 // of truth), so static bindings and runtime dispatch agree.
                 let info = Rc::clone(&self.struct_registry.borrow()[struct_id]);
+
+                self.scope_tree
+                    .declare_type(name.clone(), TypeDef::Struct(Rc::clone(&info)));
 
                 *resolved_name = Some(self.scope_tree.create_local_binding(
                     name.clone(),
@@ -1245,6 +1257,13 @@ impl AnalysisError {
     fn type_does_not_take_generic_args(name: &str, span: Span) -> Self {
         Self {
             text: format!("type `{name}` does not take generic arguments"),
+            span,
+        }
+    }
+
+    fn struct_shadows_builtin(name: &str, span: Span) -> Self {
+        Self {
+            text: format!("Struct '{name}' is not allowed to shadow the built-in type '{name}'"),
             span,
         }
     }

--- a/ndc_analyser/src/scope.rs
+++ b/ndc_analyser/src/scope.rs
@@ -1,6 +1,8 @@
 use ndc_core::StaticType;
+use ndc_core::r#struct::StructInfo;
 use ndc_parser::{Binding, Candidate, CaptureSource, ResolvedVar};
 use std::fmt::{Debug, Formatter};
+use std::rc::Rc;
 
 /// Whether a call site can fall back to element-wise tuple broadcast when no
 /// scalar overload matches the argument types directly. Set by the parser:
@@ -100,6 +102,18 @@ fn extend_dedup(
     }
 }
 
+/// What a type name refers to in the type namespace. Type names live in the
+/// same lexical scopes as value bindings but form a separate namespace: they
+/// have no runtime slots and are only consulted when lowering annotations.
+#[derive(Debug, Clone)]
+pub(crate) enum TypeDef {
+    /// A built-in type name (`Int`, `List`, …); lowering delegates to
+    /// [`StaticType::from_name_and_args`], which also checks generic arity.
+    Builtin,
+    /// A user-declared struct.
+    Struct(Rc<StructInfo>),
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum TypeBinding {
     Inferred(StaticType),
@@ -132,6 +146,8 @@ pub(crate) struct Scope {
     function_scope_idx: usize,
     identifiers: Vec<ScopeBinding>,
     upvalues: Vec<(String, CaptureSource)>,
+    /// Type names declared in this scope (separate namespace from `identifiers`).
+    types: Vec<(String, TypeDef)>,
 }
 
 impl Scope {
@@ -147,6 +163,7 @@ impl Scope {
             function_scope_idx,
             identifiers: Vec::default(),
             upvalues: Vec::default(),
+            types: Vec::default(),
         }
     }
 
@@ -162,6 +179,7 @@ impl Scope {
             function_scope_idx,
             identifiers: Vec::default(),
             upvalues: Vec::default(),
+            types: Vec::default(),
         }
     }
 
@@ -375,6 +393,10 @@ impl ScopeTree {
                 name,
                 binding: TypeBinding::Inferred(typ),
             })
+            .collect();
+        global_scope.types = StaticType::BUILTIN_TYPE_NAMES
+            .iter()
+            .map(|name| ((*name).to_string(), TypeDef::Builtin))
             .collect();
 
         Self {
@@ -882,6 +904,43 @@ impl ScopeTree {
         // Tuple<…>)` collapses to `Any` in our lattice anyway, so there's
         // nothing more precise to compute for the mixed case.
         StaticType::Any
+    }
+
+    /// Declare a type name in the current scope. Shadowing a same-named type
+    /// in an outer scope is allowed; the caller is responsible for rejecting
+    /// redeclarations within one scope and shadowing of built-in type names.
+    pub(crate) fn declare_type(&mut self, name: String, def: TypeDef) {
+        self.scopes[self.current_scope_idx].types.push((name, def));
+    }
+
+    /// Resolve a type name through the scope chain (innermost first), falling
+    /// back to the global scope where the built-in type names live.
+    pub(crate) fn resolve_type(&self, name: &str) -> Option<&TypeDef> {
+        let mut scope_idx = self.current_scope_idx;
+        loop {
+            let scope = &self.scopes[scope_idx];
+            if let Some((_, def)) = scope.types.iter().rev().find(|(n, _)| n == name) {
+                return Some(def);
+            }
+            match scope.parent_idx {
+                Some(parent_idx) => scope_idx = parent_idx,
+                None => break,
+            }
+        }
+        self.global_scope
+            .types
+            .iter()
+            .find(|(n, _)| n == name)
+            .map(|(_, def)| def)
+    }
+
+    /// Whether the current scope itself already declares a type with this
+    /// name. Used to detect illegal same-scope redefinitions.
+    pub(crate) fn has_type_in_current_scope(&self, name: &str) -> bool {
+        self.scopes[self.current_scope_idx]
+            .types
+            .iter()
+            .any(|(n, _)| n == name)
     }
 
     pub(crate) fn create_local_binding(

--- a/ndc_core/src/static_type.rs
+++ b/ndc_core/src/static_type.rs
@@ -150,6 +150,14 @@ impl fmt::Display for StaticTypeConstructionError {
 }
 
 impl StaticType {
+    /// Every type name recognised by [`StaticType::from_name_and_args`].
+    /// Must stay in sync with its match arms; the unit test
+    /// `builtin_type_names_are_constructible` guards this.
+    pub const BUILTIN_TYPE_NAMES: &'static [&'static str] = &[
+        "Any", "Never", "Bool", "Number", "Float", "Int", "Rational", "Complex", "String",
+        "Option", "Sequence", "List", "Iterator", "MinHeap", "MaxHeap", "Deque", "Tuple", "Map",
+    ];
+
     pub fn from_name_and_args(
         name: &str,
         args: Vec<Self>,
@@ -739,5 +747,21 @@ mod test {
         ])));
 
         assert!(fun.is_fn_and_matches(&[list_of_two_tuple_int, StaticType::Int]));
+    }
+
+    // Every name in BUILTIN_TYPE_NAMES must be accepted by from_name_and_args
+    // for some argument count; a name that is only rejected as "unknown type"
+    // means the two lists have drifted apart.
+    #[test]
+    fn builtin_type_names_are_constructible() {
+        for name in StaticType::BUILTIN_TYPE_NAMES {
+            let constructible = (0..=2).any(|arg_count| {
+                StaticType::from_name_and_args(name, vec![StaticType::Any; arg_count]).is_ok()
+            });
+            assert!(
+                constructible,
+                "`{name}` is listed in BUILTIN_TYPE_NAMES but from_name_and_args rejects it"
+            );
+        }
     }
 }

--- a/ndc_core/src/struct.rs
+++ b/ndc_core/src/struct.rs
@@ -65,10 +65,6 @@ impl StructRegistry {
         id
     }
 
-    pub fn find_by_name(&self, name: &str) -> Option<&Rc<StructInfo>> {
-        self.data.iter().find(|info| &*info.name == name)
-    }
-
     #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()

--- a/tests/functional/programs/015_struct/020_redefinition_error.ndc
+++ b/tests/functional/programs/015_struct/020_redefinition_error.ndc
@@ -1,4 +1,4 @@
-// Struct names are globally unique.
+// Struct names are unique within a scope.
 // expect-error: Illegal redefinition of struct 'Point'
 struct Point { x: Int }
 struct Point { y: Int }

--- a/tests/functional/programs/015_struct/029_shadow_builtin_error.ndc
+++ b/tests/functional/programs/015_struct/029_shadow_builtin_error.ndc
@@ -1,0 +1,3 @@
+// Struct names may not shadow built-in type names.
+// expect-error: Struct 'Int' is not allowed to shadow the built-in type 'Int'
+struct Int { x: Float }

--- a/tests/functional/programs/015_struct/030_same_name_in_disjoint_scopes.ndc
+++ b/tests/functional/programs/015_struct/030_same_name_in_disjoint_scopes.ndc
@@ -1,0 +1,17 @@
+// The same struct name can be reused in scopes that never coexist.
+fn make_point() {
+    struct P { x: Int }
+    let p = P(1);
+    p.x
+}
+
+fn make_pair() {
+    struct P { a: Int, b: Int }
+    let q = P(2, 3);
+    q.a + q.b
+}
+
+print(make_point());
+// expect-output: 1
+print(make_pair())
+// expect-output: 5

--- a/tests/functional/programs/015_struct/031_local_struct_not_visible_outside.ndc
+++ b/tests/functional/programs/015_struct/031_local_struct_not_visible_outside.ndc
@@ -1,0 +1,9 @@
+// A struct declared inside a function is scoped to that function; its name
+// is not a valid type annotation outside.
+// expect-error: unknown type `S`
+fn make() {
+    struct S { v: Int }
+    S(1)
+}
+
+fn check(x: S) { x.v }

--- a/tests/functional/programs/015_struct/032_shadow_outer_struct.ndc
+++ b/tests/functional/programs/015_struct/032_shadow_outer_struct.ndc
@@ -1,0 +1,14 @@
+// An inner scope may declare a struct that shadows one from an outer scope.
+struct T { a: Int }
+
+fn inner() {
+    struct T { b: Int }
+    let t = T(5);
+    t.b
+}
+
+let t = T(1);
+print(t.a);
+// expect-output: 1
+print(inner())
+// expect-output: 5

--- a/tests/functional/tests/repl.rs
+++ b/tests/functional/tests/repl.rs
@@ -223,6 +223,14 @@ fn struct_redefinition_on_later_line_errors() {
 }
 
 #[test]
+fn struct_shadowing_builtin_type_errors() {
+    repl_error(
+        &["struct Int { x: Float }"],
+        "Struct 'Int' is not allowed to shadow the built-in type 'Int'",
+    );
+}
+
+#[test]
 fn failed_line_rolls_back_struct_registry() {
     let mut interp = {
         let mut i = Interpreter::capturing();


### PR DESCRIPTION
Closes #205.

Struct names lived in a global, scope-blind registry consulted only when built-in type-name lookup failed. This let `struct Int` silently split the value and type namespaces, rejected same-named structs in disjoint scopes, and leaked function-local struct types globally.

## Changes

- Each analyser `Scope` now carries a type namespace (`name → TypeDef`) next to its value bindings; `TypeDef` is `Builtin | Struct(Rc<StructInfo>)`, leaving room for a future `Alias` variant. Built-in names are seeded into the global scope, and annotations resolve through the lexical chain (`ScopeTree::resolve_type`).
- Struct declarations now error when the name is a built-in type (`Struct 'Int' is not allowed to shadow the built-in type 'Int'`), check redefinition against the current scope only (so disjoint-scope reuse and inner-scope shadowing work), and go out of scope with their block or function.
- `StructRegistry` loses `find_by_name` and is now purely the id→layout store the compiler/VM index at runtime; name resolution is entirely the analyser's job. REPL rollback needs no new machinery because `Checkpoint` already clones the whole `ScopeTree`.
- New functional/REPL tests for the shadow diagnostic, disjoint-scope reuse, out-of-scope annotations, and user-struct shadowing; manual pages updated with the scoping rules.

## Notes for reviewers

- `StaticType::BUILTIN_TYPE_NAMES` duplicates the names in `from_name_and_args`; a unit test fails if the two drift apart.
- Side effect: field access on an instance of a function-local struct that escapes (`make().v`) is now a compile-time resolver error naming the struct type, instead of a confusing runtime miss.
- Deliberately out of scope: making such escaped-instance field access actually work (e.g. resolving fields structurally via `StructInfo` when the receiver's static type is a known struct).

🤖